### PR TITLE
[CRES-31] feat: MenuBar 컴포넌트 작성

### DIFF
--- a/src/components/common/MenuBar.tsx
+++ b/src/components/common/MenuBar.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link';
 import tw from 'tailwind-styled-components';
 
-type MenuBar = {
+type MenuBarProps = {
   focusedPosition: 'left' | 'right';
   leftText: string;
   rightText: string;
-  href: string;
+  path: string;
 };
 
 const focusStyle = {
@@ -14,11 +14,16 @@ const focusStyle = {
   notFocus: 'text-[#AC85C8] px-[23px]',
 };
 
-const MenuBar = ({ focusedPosition, leftText, rightText, href }: MenuBar) => {
+const MenuBar = ({
+  focusedPosition,
+  leftText,
+  rightText,
+  path,
+}: MenuBarProps) => {
   return (
     <Wrapper>
       <Basic
-        href={focusedPosition === 'left' ? '#' : href}
+        href={focusedPosition === 'left' ? '#' : path}
         className={`${
           focusedPosition === 'left'
             ? focusStyle['focus']
@@ -28,7 +33,7 @@ const MenuBar = ({ focusedPosition, leftText, rightText, href }: MenuBar) => {
         {leftText}
       </Basic>
       <Basic
-        href={focusedPosition === 'left' ? href : '#'}
+        href={focusedPosition === 'left' ? path : '#'}
         className={`${
           focusedPosition === 'left'
             ? focusStyle['notFocus']

--- a/src/components/common/MenuBar.tsx
+++ b/src/components/common/MenuBar.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link';
+import tw from 'tailwind-styled-components';
+
+type MenuBar = {
+  focusedPosition: 'left' | 'right';
+  leftText: string;
+  rightText: string;
+  href: string;
+};
+
+const focusStyle = {
+  focus:
+    'z-[2] border border-solid border-white bg-[#9969BB] font-bold text-white px-[26px]',
+  notFocus: 'text-[#AC85C8] px-[23px]',
+};
+
+const MenuBar = ({ focusedPosition, leftText, rightText, href }: MenuBar) => {
+  return (
+    <Wrapper>
+      <Basic
+        href={focusedPosition === 'left' ? '#' : href}
+        className={`${
+          focusedPosition === 'left'
+            ? focusStyle['focus']
+            : focusStyle['notFocus']
+        }`}
+      >
+        {leftText}
+      </Basic>
+      <Basic
+        href={focusedPosition === 'left' ? href : '#'}
+        className={`${
+          focusedPosition === 'left'
+            ? focusStyle['notFocus']
+            : focusStyle['focus']
+        } ml-[-14px]`}
+      >
+        {rightText}
+      </Basic>
+    </Wrapper>
+  );
+};
+
+export default MenuBar;
+
+const Wrapper = tw.div`
+  bg-brand
+  text-18
+  relative
+  flex
+  w-[296px]
+  rounded-[50px]
+  leading-[100%]
+`;
+
+const Basic = tw(Link)`
+  bg-brand
+  flex
+  w-[155px]
+  cursor-pointer
+  items-center
+  justify-center
+  rounded-[50px]
+  py-[14px]
+`;


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

MenuBar 컴포넌트 작성

## 🧑‍💻 PR 세부 내용
```
focusedPosition: 'left' | 'right';
leftText: string;
rightText: string;
path: string;
```

위와 같은 형식의 props를 받아서 사용합니다.

06.02 코드리뷰 바탕으로 props명 수정했습니다.
`href` -> `path`

## 📸 스크린샷 or GIF

![image](https://github.com/crescenders/crescendo-frontend/assets/87893624/637f2ae1-fdcf-4814-bb81-65b16f0086dd)

