### PR TITLE
[CRES-52] feat: Input 컴포넌트 추상화 작성

### DIFF
--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -13,7 +13,7 @@ type InputProps = InputHTMLAttributes<HTMLInputElement> & {
 
 type StyledInputProps = {
   $variant: string;
-  readonly?: boolean;
+  disabled?: boolean;
   $link?: boolean;
 };
 
@@ -69,7 +69,7 @@ const InputBox = tw.input<StyledInputProps>`
     ($variant === 'small' && 'w-[270px]') ||
     ($variant === 'middle' && 'w-[340px]') ||
     ($variant === 'large' && 'w-[550px]')}
-  ${({ readOnly }) => readOnly && 'text-text-primary bg-[#F0F0F0]'}
+  ${({ disabled }) => disabled && 'text-text-primary bg-[#F0F0F0]'}
   ${({ $link }) => ($link ? 'px-11' : 'pl-[18px]')}
   border-line-primary
   focus:border-brand

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,81 @@
+import { REQUIRED } from '@constants/index';
+import Image from 'next/image';
+import { InputHTMLAttributes, forwardRef } from 'react';
+import tw from 'tailwind-styled-components';
+
+type InputProps = InputHTMLAttributes<HTMLInputElement> & {
+  id: string;
+  variant: 'small' | 'middle' | 'large';
+  required?: boolean;
+  label: string;
+  link?: boolean;
+};
+
+type StyledInputProps = {
+  $variant: string;
+  readonly?: boolean;
+  $link?: boolean;
+};
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ id, label, required, variant, link, ...rest }, ref) => {
+    return (
+      <Container>
+        <LabelContainer>
+          {required && (
+            <span className="text-status-error mr-1">{REQUIRED}</span>
+          )}
+          <Label htmlFor={id}>{label}</Label>
+        </LabelContainer>
+        <div className="flex relative items-center">
+          {link && (
+            <Image
+              src="/svg/link.svg"
+              width={18}
+              height={18}
+              alt="link"
+              className="absolute left-4"
+            />
+          )}
+          <InputBox ref={ref} $variant={variant} $link={link} {...rest} />
+        </div>
+      </Container>
+    );
+  },
+);
+
+Input.displayName = 'Input';
+
+export default Input;
+
+const Container = tw.div`
+  flex
+  flex-col
+  gap-y-2
+`;
+
+const LabelContainer = tw.div`
+  flex
+`;
+
+const Label = tw.label`
+  text-14
+  text-text-secondary
+  font-bold
+`;
+
+const InputBox = tw.input<StyledInputProps>`
+  ${({ $variant }) =>
+    ($variant === 'small' && 'w-[270px]') ||
+    ($variant === 'middle' && 'w-[340px]') ||
+    ($variant === 'large' && 'w-[550px]')}
+  ${({ readOnly }) => readOnly && 'text-text-primary bg-[#F0F0F0]'}
+  ${({ $link }) => ($link ? 'px-11' : 'pl-[18px]')}
+  border-line-primary
+  focus:border-brand
+  placeholder:text-14
+  h-11
+  rounded-lg
+  border-[1px]
+  outline-none
+`;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export const REQUIRED = '*' as const;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -36,6 +36,9 @@ module.exports = {
           success: '#2BD239',
           error: '#FC5A2F',
         },
+        line: {
+          primary: '#C7C8D2',
+        },
       },
       boxShadow: {
         card: '0px 4px 4px rgba(0, 0, 0, 0.25), 0px 4px 4px rgba(0, 0, 0, 0.25)',


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

- close #42 

<!--수정/추가한 작업 내용을 설명해주세요.-->

## 🧑‍💻 PR 세부 내용

비제어 컴포넌트로 사용하는 것과 포커스 주는 상황을 고려해서 `forwardRef()`를 사용했습니다.
사이즈는 small, middle, large 3가지로 구분해놓았고 id, label을 필수값으로 넘겨받아서 사용합니다.
옵셔널로 disabled, required, link를 넘겨서 사용하고 필요한 attribute를 넘겨서 사용합니다.

small size
![스크린샷 2023-07-21 오전 1 44 56](https://github.com/crescenders/crescendo-frontend/assets/48711263/f7ad78ba-0f44-43d1-b454-82089e6b3dd9)

disabled
![image](https://github.com/crescenders/crescendo-frontend/assets/48711263/92c9a24c-4bde-4f09-b55d-a647603320b5)

large size, required
![image](https://github.com/crescenders/crescendo-frontend/assets/48711263/f7bdf33b-8497-4939-9106-c3158e9ddb4b)

link
![image](https://github.com/crescenders/crescendo-frontend/assets/48711263/c582b959-7f70-4a4c-adc9-8af6444a558b)

<!-- 세부 내용을 설명해주세요.-->

## 💬 요구 사항
인풋이 포커스 되었을 때 임의로 로고색인 보라색으로 스타일링 했습니다!
폼 검증 관련 에러에 대해서도 고민해봤는데 인풋 컴포넌트가 아닌 상위에서 관리하는 게 적합할 거 같아서 일단 제외했습니당
여러가지 상황 고려해서 작성해보았는데 빠진 부분 있으면 의견주세요.ㅎㅎ
