### PR TITLE
[CRES-57] Suspense, lazy import 적용

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,13 +1,14 @@
 import Image from 'next/image';
-import { useState } from 'react';
+import { lazy, useState } from 'react';
 import NavigateList from '@components/common/NavigateList';
 import Link from 'next/link';
 import { useRecoilValue } from 'recoil';
 import { userState } from '@recoil/auth';
 import useIsMounted from '@hooks/useIsMounted';
 import useModal from '@hooks/useModal';
-import LoginModal from '@components/modal/LoginModal';
 import { NAVIGATE_LIST } from '@constants/index';
+
+const LoginModal = lazy(() => import('@components/modal/LoginModal'));
 
 const Header = () => {
   const isMounted = useIsMounted();
@@ -62,7 +63,6 @@ const Header = () => {
         <span
           className="cursor-pointer text-16 font-bold text-brand"
           onClick={() => openModal(<LoginModal />)}
-          // TODO: 코드 스플리팅 하는 게 맞을까 ..
         >
           로그인 / 회원가입
         </span>

--- a/src/components/common/Loader.tsx
+++ b/src/components/common/Loader.tsx
@@ -1,0 +1,11 @@
+const Loader = () => {
+  return (
+    <div className="flex h-screen w-screen items-center justify-center gap-x-2">
+      <div className="h-3 w-3 animate-bounce1 rounded-full bg-brand" />
+      <div className="h-3 w-3 animate-bounce2 rounded-full bg-brand" />
+      <div className="h-3 w-3 animate-bounce3 rounded-full bg-brand" />
+    </div>
+  );
+};
+
+export default Loader;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,8 @@ import { Hydrate, QueryClient, QueryClientProvider } from 'react-query';
 import Layout from '@components/common/Layout';
 import { RecoilEnv, RecoilRoot } from 'recoil';
 import useIsWorker from '@hooks/useIsWorker';
+import { Suspense } from 'react';
+import Loader from '@components/common/Loader';
 
 declare global {
   interface Window {
@@ -17,7 +19,7 @@ const queryClient = new QueryClient({
     queries: {
       retry: 0,
       refetchOnWindowFocus: false,
-      useErrorBoundary: true,
+      suspense: true,
     },
     mutations: {
       retry: 0,
@@ -34,16 +36,18 @@ export default function App({ Component, pageProps }: AppProps) {
   if (!shouldRender) return null;
 
   return (
-    <RecoilRoot>
-      <QueryClientProvider client={queryClient}>
-        <ReactQueryDevtools initialIsOpen={false} />
-        <Hydrate state={pageProps.dehydratedState}>
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
-        </Hydrate>
-      </QueryClientProvider>
-    </RecoilRoot>
+    <Suspense fallback={<Loader />}>
+      <RecoilRoot>
+        <QueryClientProvider client={queryClient}>
+          <ReactQueryDevtools initialIsOpen={false} />
+          <Hydrate state={pageProps.dehydratedState}>
+            <Layout>
+              <Component {...pageProps} />
+            </Layout>
+          </Hydrate>
+        </QueryClientProvider>
+      </RecoilRoot>
+    </Suspense>
   );
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -51,6 +51,11 @@ module.exports = {
           '0px 8px 20px rgba(0, 0, 0, 0.1), 0px 2px 8px rgba(0, 0, 0, 0.1)',
         base: ' 0px 1px 2px rgba(0, 0, 0, 0.06), 0px 1px 3px rgba(0, 0, 0, 0.1)',
       },
+      animation: {
+        bounce1: 'bounce 0.5s infinite',
+        bounce2: 'bounce 0.5s infinite 50ms',
+        bounce3: 'bounce 0.5s infinite 100ms',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- close #52 
<!--수정/추가한 작업 내용을 설명해주세요.-->

## 🧑‍💻 PR 세부 내용
- `Suspense` 글로벌 적용
- `LoginModal` lazy import를 통한 코드 스플리팅
- QueryClient defaultOptions `suspense:true` 적용

## 리뷰어에게
LoginModal을 `코드스플리팅`한 이유는 다음과 같습니다.
1. 메인페이지의 번들사이즈가 매우 큼
2. 1번의 이유로 로딩 속도가 느림에도 불구하고 구글 로그인에 사용되는 스크립트와 컴포넌트를 초기 로딩 시 한 번에 가져와야함
4. 로그인 상태일때는 로그인 모달이 필요없기 때문에 로그인 모달을 번들파일에 포함 되는 것이 불필요

`Suspense`는 이후 스켈레톤 UI를 적용할 것을 고려해서 글로벌하게 적용하지 않고, 필요한 페이지에서만 비동기를 감지하는 컴포넌트를 Suspense로 감쌀 생각이였습니다. 무분별한 suspense 사용도 사용자 경험에 저해될 수 있을 거 같아요.
하지만 필요한 페이지에서 컴포넌트를 Suspense로 감쌌을 때 fallback UI가 보이질 않아 우선 진입점 파일에 적용하였습니다ㅠ
추후 해결 방법을 찾아보도록 하겠습니다.


<!-- 세부 내용을 설명해주세요.-->

## 📸 스크린샷 or GIF
<img src="https://github.com/crescenders/crescendo-frontend/assets/48711263/35196f74-6e5d-499b-bf2e-4987bdb1eb45" width="600">

<!--스크린샷 또는 GIF를 첨부해주세요.-->
