### PR TITLE
[CRES-61] 검색 결과 페이지 Skeleton UI 적용 및 Suspense 개선

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { lazy, useState } from 'react';
+import { Suspense, lazy, useState } from 'react';
 import NavigateList from '@components/common/NavigateList';
 import Link from 'next/link';
 import { useRecoilValue } from 'recoil';
@@ -7,6 +7,7 @@ import { userState } from '@recoil/auth';
 import useIsMounted from '@hooks/useIsMounted';
 import useModal from '@hooks/useModal';
 import { NAVIGATE_LIST } from '@constants/index';
+import Loader from '@components/common/Loader';
 
 const LoginModal = lazy(() => import('@components/modal/LoginModal'));
 
@@ -19,7 +20,7 @@ const Header = () => {
   if (!isMounted) return null;
 
   return (
-    <header className="fixed flex h-[70px] w-full max-w-[1024px] items-center justify-between bg-white px-7 z-[900]">
+    <header className="fixed z-[900] flex h-[70px] w-full max-w-[1024px] items-center justify-between bg-white px-7">
       <Link href={'/'}>
         <Image
           src="/svg/logo_light_mode.svg"
@@ -30,11 +31,11 @@ const Header = () => {
         />
       </Link>
       {isLogin ? (
-        <div className="flex cursor-pointer gap-x-7 relative">
+        <div className="relative flex cursor-pointer gap-x-7">
           <span className="text-16 font-medium">스터디 개설</span>
-          <div className="w-[2px] h-7 bg-[#D9D9D9]" />
+          <div className="h-7 w-[2px] bg-[#D9D9D9]" />
           <span
-            className="text-16 font-bold text-brand mr-5 relative"
+            className="relative mr-5 text-16 font-bold text-brand"
             onMouseEnter={(e: React.MouseEvent<HTMLSpanElement>) => {
               e.stopPropagation();
               setIsOpen(true);
@@ -43,10 +44,10 @@ const Header = () => {
             닉네임 님
           </span>
           {isOpen && (
-            <div className="absolute flex items-center flex-col top-[50px] left-2/4">
-              <div className="relative w-4 h-4 bg-white rotate-[135deg] top-2 shadow-sm" />
+            <div className="absolute left-2/4 top-[50px] flex flex-col items-center">
+              <div className="relative top-2 h-4 w-4 rotate-[135deg] bg-white shadow-sm" />
               <ul
-                className="flex flex-col gap-y-[1px] bg-[#D1D1D1] shadow-xl z-10"
+                className="z-10 flex flex-col gap-y-[1px] bg-[#D1D1D1] shadow-xl"
                 onMouseLeave={(e: React.MouseEvent<HTMLSpanElement>) => {
                   e.stopPropagation();
                   setIsOpen(false);
@@ -62,7 +63,13 @@ const Header = () => {
       ) : (
         <span
           className="cursor-pointer text-16 font-bold text-brand"
-          onClick={() => openModal(<LoginModal />)}
+          onClick={() =>
+            openModal(
+              <Suspense fallback={<Loader isFull />}>
+                <LoginModal />
+              </Suspense>,
+            )
+          }
         >
           로그인 / 회원가입
         </span>

--- a/src/components/common/Loader.tsx
+++ b/src/components/common/Loader.tsx
@@ -1,6 +1,14 @@
-const Loader = () => {
+type LoaderProps = {
+  isFull?: boolean;
+};
+
+const Loader = ({ isFull }: LoaderProps) => {
   return (
-    <div className="flex h-screen w-screen items-center justify-center gap-x-2">
+    <div
+      className={`${
+        isFull && 'fixed left-0 top-0 z-[999] h-screen w-screen'
+      } flex items-center justify-center gap-x-2`}
+    >
       <div className="h-3 w-3 animate-bounce1 rounded-full bg-brand" />
       <div className="h-3 w-3 animate-bounce2 rounded-full bg-brand" />
       <div className="h-3 w-3 animate-bounce3 rounded-full bg-brand" />

--- a/src/components/search/StudyList.tsx
+++ b/src/components/search/StudyList.tsx
@@ -1,0 +1,66 @@
+import { useGetStudyByKeyword } from '@hooks/queries/useGetStudy';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import useIntersection from '@hooks/useIntersection';
+import StudyListSkeleton from '@components/skeleton/StudyListSkeleton';
+import Card from '@components/common/Card';
+
+const StudyList = () => {
+  const router = useRouter();
+  const { targetRef, isIntersecting } = useIntersection({ threshold: 0.4 });
+  const {
+    data: studies,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+  } = useGetStudyByKeyword(router.query.keyword as string);
+
+  useEffect(() => {
+    if (isIntersecting && hasNextPage && !isFetching) {
+      fetchNextPage();
+    }
+  }, [isIntersecting]);
+
+  return (
+    <>
+      {studies?.pages.map(({ studies }) =>
+        studies.map(
+          ({
+            id,
+            title,
+            studyName,
+            writer,
+            tags,
+            isCanApply,
+            img,
+            participant,
+            personnel,
+            startDate,
+            endDate,
+          }) => (
+            <Card
+              path="/"
+              key={id}
+              size="big"
+              title={title}
+              studyName={studyName}
+              writer={writer}
+              tags={tags}
+              isCanApply={isCanApply}
+              img={img}
+              participant={participant}
+              personnel={personnel}
+              startDate={startDate}
+              endDate={endDate}
+            />
+          ),
+        ),
+      )}
+      {isFetchingNextPage && <StudyListSkeleton />}
+      <div className="absolute bottom-0" ref={targetRef} />
+    </>
+  );
+};
+
+export default StudyList;

--- a/src/components/skeleton/StudyListSkeleton.tsx
+++ b/src/components/skeleton/StudyListSkeleton.tsx
@@ -1,0 +1,29 @@
+const StudyListSkeleton = () => {
+  const array = Array.from({ length: 12 }, (_, i) => i);
+
+  return (
+    <>
+      {array.map((_, i) => (
+        <li
+          key={i}
+          className="flex h-[237px] w-[210px] list-none flex-col gap-y-5 rounded-[7px] bg-white shadow-header"
+        >
+          <div className="flex justify-center">
+            <div className="mt-5 h-[100px] w-[180px] animate-skeleton-gradient rounded-md" />
+          </div>
+          <div className="flex flex-col gap-y-2">
+            <div className="ml-3 h-4 w-[120px] animate-skeleton-gradient rounded-sm" />
+            <div className="ml-3 h-3 w-14 animate-skeleton-gradient rounded-sm" />
+            <div className="ml-3 h-3 w-20 animate-skeleton-gradient rounded-sm" />
+          </div>
+          <div className="flex items-center justify-between px-3">
+            <div className="h-3 w-10 animate-skeleton-gradient rounded-sm" />
+            <div className="h-3 w-9 animate-skeleton-gradient rounded-sm" />
+          </div>
+        </li>
+      ))}
+    </>
+  );
+};
+
+export default StudyListSkeleton;

--- a/src/mocks/data/studyList.json
+++ b/src/mocks/data/studyList.json
@@ -94,5 +94,53 @@
     "startDate": "2023.08.16",
     "img": "https://github.com/crescenders/crescendo-frontend/assets/87893624/d458744c-54b6-4018-9de5-ba354e6da407",
     "isCanApply": true
+  },
+  {
+    "id": 9,
+    "title": "스터디 제목",
+    "studyName": "스터디명",
+    "tags": ["태그1", "태그2", "태그3"],
+    "writer": "태현",
+    "participant": 3,
+    "personnel": 5,
+    "startDate": "2023.08.16",
+    "img": "https://github.com/crescenders/crescendo-frontend/assets/87893624/d458744c-54b6-4018-9de5-ba354e6da407",
+    "isCanApply": true
+  },
+  {
+    "id": 10,
+    "title": "스터디 제목",
+    "studyName": "스터디명",
+    "tags": ["태그1", "태그2", "태그3"],
+    "writer": "태현",
+    "participant": 3,
+    "personnel": 5,
+    "startDate": "2023.08.16",
+    "img": "https://github.com/crescenders/crescendo-frontend/assets/87893624/d458744c-54b6-4018-9de5-ba354e6da407",
+    "isCanApply": true
+  },
+  {
+    "id": 11,
+    "title": "스터디 제목",
+    "studyName": "스터디명",
+    "tags": ["태그1", "태그2", "태그3"],
+    "writer": "태현",
+    "participant": 3,
+    "personnel": 5,
+    "startDate": "2023.08.16",
+    "img": "https://github.com/crescenders/crescendo-frontend/assets/87893624/d458744c-54b6-4018-9de5-ba354e6da407",
+    "isCanApply": true
+  },
+  {
+    "id": 12,
+    "title": "스터디 제목",
+    "studyName": "스터디명",
+    "tags": ["태그1", "태그2", "태그3"],
+    "writer": "태현",
+    "participant": 3,
+    "personnel": 5,
+    "startDate": "2023.08.16",
+    "img": "https://github.com/crescenders/crescendo-frontend/assets/87893624/d458744c-54b6-4018-9de5-ba354e6da407",
+    "isCanApply": true
   }
 ]

--- a/src/mocks/handlers/studyHandlers.ts
+++ b/src/mocks/handlers/studyHandlers.ts
@@ -5,7 +5,7 @@ import { CONFIG } from '@config';
 export const studyHandlers = [
   // 검색어로 스터디 조회
   rest.get(`${CONFIG.BASE_URL}/api/v1/studies`, (req, res, ctx) => {
-    const PAGINATE_UNIT = 4;
+    const PAGINATE_UNIT = 12;
     const keyword = String(req.url.searchParams.get('keyword'));
     const page = Number(req.url.searchParams.get('page'));
     const findByKeyword = studyList.filter(

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,8 +5,6 @@ import { Hydrate, QueryClient, QueryClientProvider } from 'react-query';
 import Layout from '@components/common/Layout';
 import { RecoilEnv, RecoilRoot } from 'recoil';
 import useIsWorker from '@hooks/useIsWorker';
-import { Suspense } from 'react';
-import Loader from '@components/common/Loader';
 
 declare global {
   interface Window {
@@ -36,18 +34,16 @@ export default function App({ Component, pageProps }: AppProps) {
   if (!shouldRender) return null;
 
   return (
-    <Suspense fallback={<Loader />}>
-      <RecoilRoot>
-        <QueryClientProvider client={queryClient}>
-          <ReactQueryDevtools initialIsOpen={false} />
-          <Hydrate state={pageProps.dehydratedState}>
-            <Layout>
-              <Component {...pageProps} />
-            </Layout>
-          </Hydrate>
-        </QueryClientProvider>
-      </RecoilRoot>
-    </Suspense>
+    <RecoilRoot>
+      <QueryClientProvider client={queryClient}>
+        <ReactQueryDevtools initialIsOpen={false} />
+        <Hydrate state={pageProps.dehydratedState}>
+          <Layout>
+            <Component {...pageProps} />
+          </Layout>
+        </Hydrate>
+      </QueryClientProvider>
+    </RecoilRoot>
   );
 }
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,4 +1,4 @@
-import Card from '@components/common/Card';
+import StudyList from '@components/search/StudyList';
 import PageLayout from '@components/common/PageLayout';
 import SelectBox from '@components/common/SelectBox';
 import {
@@ -7,30 +7,14 @@ import {
   SORT_OBJ,
   SortStateType,
 } from '@constants/search';
-import { useGetStudyByKeyword } from '@hooks/queries/useGetStudy';
-import useIntersection from '@hooks/useIntersection';
-import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { Suspense, useState } from 'react';
 import tw from 'tailwind-styled-components';
+import StudyListSkeleton from '@components/skeleton/StudyListSkeleton';
 
 const Search = () => {
-  const router = useRouter();
-  const { targetRef, isIntersecting } = useIntersection({ threshold: 0.4 });
-  const {
-    data: studies,
-    fetchNextPage,
-    hasNextPage,
-    isFetching,
-  } = useGetStudyByKeyword(router.query.keyword as string);
   const [isOpen, setIsOpen] = useState<SortStateType>(SORT_OBJ);
   const [leftValue, setLeftValue] = useState<string>('최신순');
   const [rightValue, setRightValue] = useState<string>('모집중');
-
-  useEffect(() => {
-    if (isIntersecting && hasNextPage && !isFetching) {
-      fetchNextPage();
-    }
-  }, [isIntersecting]);
 
   return (
     <PageLayout>
@@ -50,58 +34,20 @@ const Search = () => {
           setIsOpen={setIsOpen}
         />
       </div>
-      {studies &&
-        (studies.pages.flatMap((v) => v.studies).length > 0 ? (
-          <StudyList>
-            {studies.pages.map(({ studies }) =>
-              studies.map(
-                ({
-                  id,
-                  title,
-                  studyName,
-                  writer,
-                  tags,
-                  isCanApply,
-                  img,
-                  participant,
-                  personnel,
-                  startDate,
-                  endDate,
-                }) => (
-                  <Card
-                    path="/"
-                    key={id}
-                    size="big"
-                    title={title}
-                    studyName={studyName}
-                    writer={writer}
-                    tags={tags}
-                    isCanApply={isCanApply}
-                    img={img}
-                    participant={participant}
-                    personnel={personnel}
-                    startDate={startDate}
-                    endDate={endDate}
-                  />
-                ),
-              ),
-            )}
-          </StudyList>
-        ) : (
-          <div className="flex justify-center items-center h-[50vh]">
-            <span className="text-status-error">검색 결과가 없습니다.</span>
-          </div>
-        ))}
-      <div ref={targetRef} />
+      <StudyListContainer>
+        <Suspense fallback={<StudyListSkeleton />}>
+          <StudyList />
+        </Suspense>
+      </StudyListContainer>
     </PageLayout>
   );
 };
 
 export default Search;
 
-const StudyList = tw.div`
-  mb-[100px]
-  mt-[120px]
+const StudyListContainer = tw.div`
+  mb-8
+  mt-[100px]
   flex
   flex-wrap
   justify-center

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -55,6 +55,20 @@ module.exports = {
         bounce1: 'bounce 0.5s infinite',
         bounce2: 'bounce 0.5s infinite 50ms',
         bounce3: 'bounce 0.5s infinite 100ms',
+        'skeleton-gradient': 'skeleton-gradient 1.35s infinite ease-in-out',
+      },
+      keyframes: {
+        'skeleton-gradient': {
+          '0%': {
+            'background-color': 'rgba(165, 165, 165, 0.7)',
+          },
+          '50%': {
+            'background-color': 'rgba(165, 165, 165, 0.99)',
+          },
+          '100%': {
+            'background-color': 'rgba(165, 165, 165, 0.7)',
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

- close #61 

<!--수정/추가한 작업 내용을 설명해주세요.-->

## 🧑‍💻 PR 세부 내용

- 검색 결과 페이지 Skeleton UI 적용
- Suspense 컴포넌트 별 적용

<!-- 세부 내용을 설명해주세요.-->

## 리뷰어에게
1. 저번에 fallback UI가 보이지 않았던 이유는 Suspense는 감싼 컴포넌트에서 Proimise 상태를 감지해야 작동하기 때문입니다.
그래서 `StudyList` 컴포넌트로 분리한 후 Suspense로 감쌌습니다.
진입점 파일에 감싸게 되면 모든 컴포넌트가 다 로딩이 되어서야 사용자는 화면을 볼 수 있습니다.  로딩이 지연되는 컴포넌트를 기다리지 않고 나머지 컴포넌트를 먼저 렌더링 할 수 있게 됩니다.
2. 빌드 시 TailwindCSS order warning 문구가 너무 많아서 클래스 네임 순서를 수정했습니다.

## 📸 스크린샷 or GIF

![화면 기록 2023-08-17 오후 6 22 52](https://github.com/crescenders/crescendo-frontend/assets/48711263/3f6bf355-4625-4a8c-a75c-90ef8f96b505)


<!--스크린샷 또는 GIF를 첨부해주세요.-->
