### PR TITLE
[CRES-71] middleware를 통해 로그인 여부에 따라 페이지 접근 제어 및 리다이렉션 적용

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -4,7 +4,6 @@ import NavigateList from '@components/common/NavigateList';
 import Link from 'next/link';
 import { useRecoilValue } from 'recoil';
 import { userState } from '@recoil/auth';
-import useIsMounted from '@hooks/useIsMounted';
 import useModal from '@hooks/useModal';
 import { NAVIGATE_LIST } from '@constants/index';
 import Loader from '@components/common/Loader';
@@ -12,12 +11,9 @@ import Loader from '@components/common/Loader';
 const LoginModal = lazy(() => import('@components/modal/LoginModal'));
 
 const Header = () => {
-  const isMounted = useIsMounted();
   const { isLogin, username } = useRecoilValue(userState);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const { openModal } = useModal();
-
-  if (!isMounted) return null;
 
   return (
     <header className="fixed z-[900] flex h-[70px] w-full max-w-[1024px] items-center justify-between bg-white px-7">

--- a/src/hooks/queries/useGetProfile.ts
+++ b/src/hooks/queries/useGetProfile.ts
@@ -1,10 +1,8 @@
 import userApi from '@apis/user/userApi';
 import { useQuery } from '@tanstack/react-query';
-import { getToken } from '@utils/token';
 
 export const useGetProfile = () => {
   return useQuery(['useGetProfile'], () => userApi.getUser(), {
-    enabled: !!getToken().accessToken,
     staleTime: Infinity,
     cacheTime: Infinity,
   });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const token = req.cookies.get('refreshToken');
+
+  if (!token) return NextResponse.redirect(new URL('/', req.url));
+}
+
+export const config = {
+  matcher: ['/mypage/:path*', '/study/create'],
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import Layout from '@components/common/Layout';
 import { RecoilEnv, RecoilRoot } from 'recoil';
 import useIsWorker from '@hooks/useIsWorker';
+import useIsMounted from '@hooks/useIsMounted';
 
 declare global {
   interface Window {
@@ -34,8 +35,9 @@ RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
 
 export default function App({ Component, pageProps }: AppProps) {
   const { shouldRender } = useIsWorker();
+  const isMounted = useIsMounted();
 
-  if (!shouldRender) return null;
+  if (!shouldRender || !isMounted) return null;
 
   return (
     <RecoilRoot>


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

- close #87 

<!--수정/추가한 작업 내용을 설명해주세요.-->

## 🧑‍💻 PR 세부 내용

- middleware를 통해 쿠키 여부에 따라 리다이렉션을 적용하였습니다.
- 페이지에 접근하기 전에 미들웨어를 통해 접근 여부를 검사합니다.
- 우선 /mypage와 /study/create 만 적용하였습니다.

<!-- 세부 내용을 설명해주세요.-->

## 리뷰어에게

_app.tsx에 전역으로 `useIsMounted`를 적용한 이유는 다음과 같습니다.
- 개발 환경에서는 문제없으나 배포 환경에서 빌드 시 에러가 발생합니다.
- /mypage에 접근 시 리다이렉션이 최우선적으로 적용되어야함에도 불구하고 API 콜이 들어갑니다. 유사한 사례는 찾지 못했습니다.
- 401 에러가 발생하고 Axios Interceptor의 토큰 재발급 로직이 실행되면서 서버사이드에서 document.cookie에 접근하기 때문에 에러가 발생합니다.
- 전역에 useIsMounted를 적용해 해결할 수 있었지만 **우려되는 점**은 전역에 useIsMounted을 적용했기 때문에 어떤 사이드 이펙트를 가져올 지 모른다는 점입니다.
- Next.js 특징때문에 어쩔 수 없는 문제로 보이며 토큰이 안 담겨졌을 때 에러코드를 구분할 수 있다면 해결할 수 있을 것 같아요.

개발하시면서 해결 방법 생각나면 공유 부탁드립니다!

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
