### PR TITLE
[CRES-83] 스터디 그룹 목록 검색 및 필터링 기능 구현

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -5,26 +5,3 @@ type TResponse = {
 };
 
 type TDate = Date | null;
-
-type TLink = {
-  rel: string;
-  href: string;
-};
-
-type TLeaders = {
-  username: string;
-  _links: TLink[];
-};
-
-type TStudy = {
-  head_image: string;
-  leaders: TLeaders[];
-  post_title: string;
-  study_name: string;
-  until_deadline: number;
-  is_closed: boolean;
-  tags: string[];
-  categories: string[];
-  current_member_count: number;
-  member_limit: number;
-};

--- a/src/apis/study/study.d.ts
+++ b/src/apis/study/study.d.ts
@@ -1,28 +1,48 @@
 type StudyList = {
-  id: number;
-  title: string;
-  studyName: string;
-  writer: string;
-  tags: string[];
-  img: string;
-  participant: number;
-  personnel: number;
-  startDate: string;
-  endDate: string;
-  isCanApply: boolean;
+  next: string;
+  previous: string;
+  results: [
+    Study & {
+      uuid: string;
+      _links: Link[];
+    },
+  ];
 };
 
-type StudyDetail = TStudy & {
+type StudyDetail = Study & {
   created_at: string;
   updated_at: string;
   post_content: string;
   start_date: string;
   end_date: string;
   deadline: string;
-  _links: TLink[];
+  _links: Link[];
 };
 
-type CreateStudy = TStudy & {
+type CreateStudy = Study & {
   uuid: string;
-  _links: TLink[];
+  _links: Link[];
+};
+
+type Link = {
+  rel: string;
+  href: string;
+};
+
+type Leaders = {
+  username: string;
+  _links: Link[];
+};
+
+type Study = {
+  head_image: string;
+  leaders: Leaders[];
+  post_title: string;
+  study_name: string;
+  until_deadline: number;
+  is_closed: boolean;
+  tags: string[];
+  categories: string[];
+  current_member_count: number;
+  member_limit: number;
 };

--- a/src/apis/study/studyApi.ts
+++ b/src/apis/study/studyApi.ts
@@ -2,7 +2,7 @@ import instance from '@apis/instance';
 
 const studyApi = {
   getStudyGroupList: async (params = ''): Promise<StudyList> => {
-    const { data } = await instance.get(`/api/v1/studygroup/studies?${params}`);
+    const { data } = await instance.get(`/api/v1/studygroup/studies${params}`);
     return data;
   },
   createStudy: async (formData: FormData): Promise<CreateStudy> => {

--- a/src/apis/study/studyApi.ts
+++ b/src/apis/study/studyApi.ts
@@ -1,13 +1,8 @@
 import instance from '@apis/instance';
 
 const studyApi = {
-  getStudyByKeyword: async (
-    keyword: string,
-    page: number,
-  ): Promise<StudyList[]> => {
-    const { data } = await instance.get(
-      `/api/v1/studies?keyword=${keyword}&page=${page}`,
-    );
+  getStudyGroupList: async (params = ''): Promise<StudyList> => {
+    const { data } = await instance.get(`/api/v1/studygroup/studies?${params}`);
     return data;
   },
   createStudy: async (formData: FormData): Promise<CreateStudy> => {

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -35,7 +35,6 @@ const Card = ({
   endDate,
   deadline,
 }: CardProps) => {
-  console.log(deadline);
   return (
     <Wrapper href={path} className={`${WrapperStyle[size]}`}>
       {size === 'medium' && !isApprove && (

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -1,28 +1,28 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import tw from 'tailwind-styled-components';
-import getDiffDate from 'utils/getDiffDate';
 
 type CardProps = {
   path: string;
   size: 'big' | 'medium' | 'small';
-  isCanApply?: boolean;
+  isClosed?: boolean;
   isApprove?: boolean;
   img: string;
   title?: string;
   studyName: string;
   tags?: string[];
-  writer?: string;
+  writer?: string[];
   participant?: number;
   personnel?: number;
-  startDate: string;
+  startDate?: string;
   endDate?: string;
+  deadline?: number;
 };
 
 const Card = ({
   path,
   size,
-  isCanApply,
+  isClosed,
   isApprove,
   img,
   title,
@@ -33,27 +33,37 @@ const Card = ({
   participant,
   startDate,
   endDate,
+  deadline,
 }: CardProps) => {
+  console.log(deadline);
   return (
     <Wrapper href={path} className={`${WrapperStyle[size]}`}>
       {size === 'medium' && !isApprove && (
         <div className="absolute z-[2] h-[172px] w-[187px] rounded-[7px] bg-white/50"></div>
       )}
       <ImageBox className={`${ImageBoxStyle[size]} relative`}>
-        {size === 'big' && isCanApply && (
+        {size === 'big' && !isClosed && (
           <DDayBox
             className={`${
-              typeof getDiffDate(startDate) === 'number'
+              deadline && deadline > 0
                 ? 'bg-[#8266FF]'
-                : 'bg-status-error'
+                : deadline === 0
+                ? 'bg-status-error'
+                : ''
             } `}
           >
-            D - {getDiffDate(startDate)}
+            {deadline && deadline > 0 && deadline < 99
+              ? `D - ${deadline}`
+              : deadline === 0
+              ? 'D-Day'
+              : deadline && deadline >= 99
+              ? 'D - 99+'
+              : ''}
           </DDayBox>
         )}
         <Image src={img} alt="thumbnail" fill className="object-cover" />
-        {size === 'big' && !isCanApply && (
-          <div className="absolute flex h-full  w-full flex-col items-center justify-center gap-2 bg-black/50">
+        {size === 'big' && isClosed && (
+          <div className="absolute flex h-full w-full flex-col items-center justify-center gap-2 bg-black/50">
             <Image
               src="/svg/check_circle.svg"
               width={52}
@@ -66,18 +76,23 @@ const Card = ({
       </ImageBox>
       <InfoBox className={`${InfoBoxStyle[size]}`}>
         {size === 'big' ? (
-          <>
-            <div className="text-14">{title}</div>
+          <div className="pt-1">
+            <div className="overflow-hidden text-ellipsis whitespace-nowrap text-14">
+              {title}
+            </div>
             <div className="my-[8px] text-12">{studyName}</div>
             <div className="flex gap-x-1">
               {tags?.map((tag) => (
-                <div key={tag} className="mb-[8px] text-[8px]">
-                  {tag}
+                <div key={tag} className="">
+                  <span className="text-[9px]">#{tag}</span>
                 </div>
               ))}
             </div>
-
-            <div className="flex items-center justify-between text-[12px] text-[#666666]">
+            <div
+              className={`${
+                !tags?.length && 'mt-6'
+              } flex items-center justify-between text-[12px] text-[#666666]`}
+            >
               <div>{writer}</div>
               <div className="flex items-center justify-center gap-[5px]">
                 <Image
@@ -89,20 +104,20 @@ const Card = ({
                 {participant} / {personnel}
               </div>
             </div>
-          </>
+          </div>
         ) : (
           <>
             <div
               className={`${
                 size === 'medium' ? 'text-14' : 'text-12'
-              } mb-[4px] font-bold `}
+              } mb-[4px] font-bold`}
             >
               {studyName}
             </div>
             <div
               className={`${
                 size === 'medium' ? 'text-12' : 'text-10'
-              } text-text-primary `}
+              } text-text-primary`}
             >
               {startDate} ~ {endDate}
             </div>
@@ -124,7 +139,7 @@ const Wrapper = tw(Link)`
 `;
 
 const WrapperStyle = {
-  big: 'w-[210px] h-[237px]',
+  big: 'w-[210px] h-[245px]',
   medium: 'w-[187px] h-[172px]',
   small: 'w-[160px] h-[148px]',
 };

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -7,28 +7,31 @@ type InputProps = InputHTMLAttributes<HTMLInputElement> & {
   id: string;
   variant: 'small' | 'middle' | 'large';
   required?: boolean;
-  label: string;
+  label?: string;
   link?: boolean;
   error?: string;
 };
 
 type StyledInputProps = {
   $variant: string;
-  disabled?: boolean;
-  $link?: boolean;
+  disabled: boolean;
+  $link: boolean;
+  $label: string;
 };
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ id, label, required, variant, link, error, ...rest }, ref) => {
     return (
-      <Container>
-        <LabelContainer>
-          {required && (
-            <span className="text-status-error mr-1">{REQUIRED}</span>
-          )}
-          <Label htmlFor={id}>{label}</Label>
-        </LabelContainer>
-        <div className="flex relative items-center">
+      <Container $label={label}>
+        {label && (
+          <LabelContainer>
+            {required && (
+              <span className="mr-1 text-status-error">{REQUIRED}</span>
+            )}
+            <Label htmlFor={id}>{label}</Label>
+          </LabelContainer>
+        )}
+        <div className="relative flex items-center">
           {link && (
             <Image
               src="/svg/link.svg"
@@ -40,7 +43,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           )}
           <InputBox ref={ref} $variant={variant} $link={link} {...rest} />
         </div>
-        <span className="text-status-error text-12 h-2">{error}</span>
+        {error && (
+          <span className="h-2 text-12 text-status-error">{error}</span>
+        )}
       </Container>
     );
   },
@@ -50,10 +55,10 @@ Input.displayName = 'Input';
 
 export default Input;
 
-const Container = tw.div`
+const Container = tw.div<Partial<StyledInputProps>>`
+  ${({ $label }) => $label && 'gap-y-2'}
   flex
   flex-col
-  gap-y-2
 `;
 
 const LabelContainer = tw.div`
@@ -66,7 +71,7 @@ const Label = tw.label`
   font-bold
 `;
 
-const InputBox = tw.input<StyledInputProps>`
+const InputBox = tw.input<Partial<StyledInputProps>>`
   ${({ $variant }) =>
     ($variant === 'small' && 'w-[270px]') ||
     ($variant === 'middle' && 'w-[340px]') ||

--- a/src/components/common/SelectBox.tsx
+++ b/src/components/common/SelectBox.tsx
@@ -1,7 +1,7 @@
 import { OptionsType, SORT_OBJ, SortStateType } from '@constants/search';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useEffect } from 'react';
 import tw from 'tailwind-styled-components';
 
 type SelectListProps = {
@@ -10,6 +10,8 @@ type SelectListProps = {
   setValue: Dispatch<SetStateAction<string>>;
   isOpen: SortStateType;
   setIsOpen: Dispatch<SetStateAction<SortStateType>>;
+  queryParam?: string;
+  setQueryParam?: Dispatch<SetStateAction<string>>;
 };
 
 const SelectBox = ({
@@ -18,8 +20,11 @@ const SelectBox = ({
   setValue,
   isOpen,
   setIsOpen,
+  queryParam,
+  setQueryParam,
 }: SelectListProps) => {
   const router = useRouter();
+
   return (
     <div className="flex flex-col">
       <SelectBoxWrapper
@@ -46,21 +51,15 @@ const SelectBox = ({
                     : { ...prev, [value]: true };
                 });
                 setValue(name);
-                name === '최신순' || name === '마감순'
-                  ? router.replace({
-                      pathname: router.pathname,
-                      query: {
-                        ...router.query,
-                        ordering: query,
-                      },
-                    })
-                  : router.replace({
-                      pathname: router.pathname,
-                      query: {
-                        ...router.query,
-                        is_closed: query,
-                      },
-                    });
+                !queryParam &&
+                  router.replace({
+                    pathname: router.pathname,
+                    query: {
+                      ...router.query,
+                      is_closed: query,
+                    },
+                  });
+                setQueryParam && queryParam && setQueryParam(queryParam);
               }}
             >
               {name}

--- a/src/components/common/SelectBox.tsx
+++ b/src/components/common/SelectBox.tsx
@@ -1,7 +1,7 @@
 import { OptionsType, SORT_OBJ, SortStateType } from '@constants/search';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { Dispatch, SetStateAction, useEffect } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import tw from 'tailwind-styled-components';
 
 type SelectListProps = {
@@ -10,8 +10,6 @@ type SelectListProps = {
   setValue: Dispatch<SetStateAction<string>>;
   isOpen: SortStateType;
   setIsOpen: Dispatch<SetStateAction<SortStateType>>;
-  queryParam?: string;
-  setQueryParam?: Dispatch<SetStateAction<string>>;
 };
 
 const SelectBox = ({
@@ -20,8 +18,6 @@ const SelectBox = ({
   setValue,
   isOpen,
   setIsOpen,
-  queryParam,
-  setQueryParam,
 }: SelectListProps) => {
   const router = useRouter();
 
@@ -51,15 +47,21 @@ const SelectBox = ({
                     : { ...prev, [value]: true };
                 });
                 setValue(name);
-                !queryParam &&
-                  router.replace({
-                    pathname: router.pathname,
-                    query: {
-                      ...router.query,
-                      is_closed: query,
-                    },
-                  });
-                setQueryParam && queryParam && setQueryParam(queryParam);
+                name === '최신순' || name === '마감순'
+                  ? router.replace({
+                      pathname: router.pathname,
+                      query: {
+                        ...router.query,
+                        ordering: query,
+                      },
+                    })
+                  : router.replace({
+                      pathname: router.pathname,
+                      query: {
+                        ...router.query,
+                        is_closed: query,
+                      },
+                    });
               }}
             >
               {name}

--- a/src/components/common/SelectBox.tsx
+++ b/src/components/common/SelectBox.tsx
@@ -1,10 +1,11 @@
-import { SORT_OBJ, SelectListType, SortStateType } from '@constants/search';
+import { OptionsType, SORT_OBJ, SortStateType } from '@constants/search';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import { Dispatch, SetStateAction } from 'react';
 import tw from 'tailwind-styled-components';
 
 type SelectListProps = {
-  options: SelectListType[];
+  options: OptionsType;
   value: string;
   setValue: Dispatch<SetStateAction<string>>;
   isOpen: SortStateType;
@@ -18,6 +19,7 @@ const SelectBox = ({
   isOpen,
   setIsOpen,
 }: SelectListProps) => {
+  const router = useRouter();
   return (
     <div className="flex flex-col">
       <SelectBoxWrapper
@@ -29,12 +31,12 @@ const SelectBox = ({
         }
         className={`${isOpen[value] ? 'border-[#8266FF]' : 'border-[#E2E0E0]'}`}
       >
-        <span className="text-13 ml-3">{value}</span>
+        <span className="ml-3 text-13">{value}</span>
         <Image src={'/svg/chevron-down.svg'} width={16} height={16} alt="" />
       </SelectBoxWrapper>
       {isOpen[value] && (
         <SelectList>
-          {options.map(({ id, name }) => (
+          {options.map(({ id, name, query }) => (
             <SelectItem
               key={id}
               onClick={() => {
@@ -44,6 +46,21 @@ const SelectBox = ({
                     : { ...prev, [value]: true };
                 });
                 setValue(name);
+                name === '최신순' || name === '마감순'
+                  ? router.replace({
+                      pathname: router.pathname,
+                      query: {
+                        ...router.query,
+                        ordering: query,
+                      },
+                    })
+                  : router.replace({
+                      pathname: router.pathname,
+                      query: {
+                        ...router.query,
+                        is_closed: query,
+                      },
+                    });
               }}
             >
               {name}
@@ -83,6 +100,7 @@ const SelectList = tw.ul`
   rounded-[7px]
   border-[1px]
   border-[#E2E0E0]
+  bg-white
 `;
 
 const SelectItem = tw.li`

--- a/src/components/search/StudyList.tsx
+++ b/src/components/search/StudyList.tsx
@@ -1,4 +1,4 @@
-import { useGetStudyByKeyword } from '@hooks/queries/useGetStudy';
+import { useGetStudyGroupList } from '@hooks/queries/useGetStudy';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import useIntersection from '@hooks/useIntersection';
@@ -8,57 +8,55 @@ import Card from '@components/common/Card';
 const StudyList = () => {
   const router = useRouter();
   const { targetRef, isIntersecting } = useIntersection({ threshold: 0.4 });
+  const params = router.asPath.split('?')[1];
   const {
     data: studies,
     fetchNextPage,
     hasNextPage,
     isFetching,
-    isFetchingNextPage,
-  } = useGetStudyByKeyword(router.query.keyword as string);
+  } = useGetStudyGroupList(params);
 
   useEffect(() => {
     if (isIntersecting && hasNextPage && !isFetching) {
       fetchNextPage();
     }
-  }, [isIntersecting]);
+  }, [isIntersecting, isFetching]);
 
   return (
     <>
-      {studies?.pages.map(({ studies }) =>
-        studies.map(
+      {studies?.pages.flatMap((pages) =>
+        pages.results.map(
           ({
-            id,
-            title,
-            studyName,
-            writer,
+            uuid,
+            head_image,
+            leaders,
+            post_title,
+            study_name,
+            is_closed,
             tags,
-            isCanApply,
-            img,
-            participant,
-            personnel,
-            startDate,
-            endDate,
+            current_member_count,
+            member_limit,
+            until_deadline,
           }) => (
             <Card
-              path={`/study/detail/${id}`}
-              key={id}
+              path={`/study/detail/${uuid}`}
+              key={uuid}
               size="big"
-              title={title}
-              studyName={studyName}
-              writer={writer}
+              title={post_title}
+              studyName={study_name}
+              writer={leaders.map((leader) => leader.username)}
               tags={tags}
-              isCanApply={isCanApply}
-              img={img}
-              participant={participant}
-              personnel={personnel}
-              startDate={startDate}
-              endDate={endDate}
+              isClosed={is_closed}
+              img={head_image}
+              participant={current_member_count}
+              personnel={member_limit}
+              deadline={until_deadline}
             />
           ),
         ),
       )}
-      {isFetchingNextPage && <StudyListSkeleton />}
-      <div className="absolute bottom-0" ref={targetRef} />
+      {isFetching && <StudyListSkeleton />}
+      <div ref={targetRef} />
     </>
   );
 };

--- a/src/constants/search.ts
+++ b/src/constants/search.ts
@@ -1,8 +1,3 @@
-export type SelectListType = {
-  id: number;
-  name: SortType;
-};
-
 export type SortType = '최신순' | '마감순' | '모집중' | '모집완료';
 
 export type SortStateType = {
@@ -16,12 +11,14 @@ export const SORT_OBJ: SortStateType = {
   모집완료: false,
 };
 
-export const LEFT_SELECT_OPTION: SelectListType[] = [
-  { id: 1, name: '최신순' },
-  { id: 2, name: '마감순' },
+export const LEFT_SELECT_OPTION = [
+  { id: 1, name: '최신순', query: 'created_at' },
+  { id: 2, name: '마감순', query: 'deadline' },
 ];
 
-export const RIGHT_SELECT_OPTION: SelectListType[] = [
-  { id: 1, name: '모집중' },
-  { id: 2, name: '모집완료' },
+export const RIGHT_SELECT_OPTION = [
+  { id: 1, name: '모집중', query: 'false' },
+  { id: 2, name: '모집완료', query: 'false' },
 ];
+
+export type OptionsType = typeof LEFT_SELECT_OPTION;

--- a/src/constants/search.ts
+++ b/src/constants/search.ts
@@ -18,7 +18,7 @@ export const LEFT_SELECT_OPTION = [
 
 export const RIGHT_SELECT_OPTION = [
   { id: 1, name: '모집중', query: 'false' },
-  { id: 2, name: '모집완료', query: 'false' },
+  { id: 2, name: '모집완료', query: 'true' },
 ];
 
 export type OptionsType = typeof LEFT_SELECT_OPTION;

--- a/src/hooks/queries/useGetStudy.ts
+++ b/src/hooks/queries/useGetStudy.ts
@@ -7,8 +7,8 @@ export const useGetStudyGroupList = (params = '') => {
     ({ pageParam = '' }) => {
       const cursor = params
         ? pageParam
-          ? params + `&${pageParam}`
-          : params
+          ? `?${params}` + `&${pageParam}`
+          : `?${params}`
         : `${pageParam}`;
       return studyApi.getStudyGroupList(cursor).then((studies) => studies);
     },

--- a/src/hooks/queries/useGetStudy.ts
+++ b/src/hooks/queries/useGetStudy.ts
@@ -1,18 +1,21 @@
 import studyApi from '@apis/study/studyApi';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
-export const useGetStudyByKeyword = (keyword: string) => {
+export const useGetStudyGroupList = (params = '') => {
   return useInfiniteQuery(
-    ['useGetStudy', keyword],
-    ({ pageParam = 1 }) =>
-      studyApi
-        .getStudyByKeyword(keyword, pageParam)
-        .then((studies) => ({ studies, page: pageParam })),
+    ['useGetStudyGroupList', params],
+    ({ pageParam = '' }) => {
+      const cursor = params
+        ? pageParam
+          ? params + `&${pageParam}`
+          : params
+        : `${pageParam}`;
+      return studyApi.getStudyGroupList(cursor).then((studies) => studies);
+    },
     {
       getNextPageParam: (lastPage) => {
-        return lastPage.studies.length > 0 ? lastPage.page + 1 : undefined;
+        return lastPage.next ? lastPage.next.split('?')[1] : null;
       },
-      enabled: !!keyword,
     },
   );
 };

--- a/src/hooks/useStudyList.ts
+++ b/src/hooks/useStudyList.ts
@@ -1,0 +1,55 @@
+import { useRouter } from 'next/router';
+
+const useStudyList = () => {
+  const router = useRouter();
+
+  const handleCategoryList = (name: string) => {
+    const { categories, ...restQuery } = router.query;
+    if (categories?.includes(name)) {
+      if (typeof categories === 'string') {
+        router.replace({
+          pathname: router.pathname,
+          query: {
+            ...restQuery,
+          },
+        });
+      } else if (Array.isArray(categories))
+        router.replace({
+          pathname: router.pathname,
+          query: {
+            ...router.query,
+            categories: categories.filter((category) => category !== name),
+          },
+        });
+    } else {
+      if (typeof categories === 'string')
+        router.replace({
+          pathname: router.pathname,
+          query: {
+            ...router.query,
+            categories: [categories, name],
+          },
+        });
+      else if (Array.isArray(categories))
+        router.replace({
+          pathname: router.pathname,
+          query: {
+            ...router.query,
+            categories: [...categories, name],
+          },
+        });
+      else
+        router.replace({
+          pathname: router.pathname,
+          query: {
+            ...router.query,
+            categories: name,
+          },
+        });
+    }
+  };
+
+  return { handleCategoryList };
+};
+
+export default useStudyList;

--- a/src/hooks/useStudyList.ts
+++ b/src/hooks/useStudyList.ts
@@ -2,20 +2,22 @@ import { useRouter } from 'next/router';
 
 const useStudyList = () => {
   const router = useRouter();
+  const { pathname } = router;
 
   const handleCategoryList = (name: string) => {
     const { categories, ...restQuery } = router.query;
+
     if (categories?.includes(name)) {
       if (typeof categories === 'string') {
         router.replace({
-          pathname: router.pathname,
+          pathname,
           query: {
             ...restQuery,
           },
         });
       } else if (Array.isArray(categories))
         router.replace({
-          pathname: router.pathname,
+          pathname,
           query: {
             ...router.query,
             categories: categories.filter((category) => category !== name),
@@ -24,7 +26,7 @@ const useStudyList = () => {
     } else {
       if (typeof categories === 'string')
         router.replace({
-          pathname: router.pathname,
+          pathname,
           query: {
             ...router.query,
             categories: [categories, name],
@@ -32,7 +34,7 @@ const useStudyList = () => {
         });
       else if (Array.isArray(categories))
         router.replace({
-          pathname: router.pathname,
+          pathname,
           query: {
             ...router.query,
             categories: [...categories, name],
@@ -40,7 +42,7 @@ const useStudyList = () => {
         });
       else
         router.replace({
-          pathname: router.pathname,
+          pathname,
           query: {
             ...router.query,
             categories: name,
@@ -49,7 +51,28 @@ const useStudyList = () => {
     }
   };
 
-  return { handleCategoryList };
+  const studySearchRouter = (value: string) => {
+    if (value === '') router.replace(pathname);
+    else if (value.startsWith('#'))
+      router.replace({
+        pathname,
+        query: {
+          ...router.query,
+          tags: value.replace('#', ''),
+        },
+      });
+    else
+      router.replace({
+        pathname,
+        query: {
+          ...router.query,
+          post_title: value,
+          study_title: value,
+        },
+      });
+  };
+
+  return { handleCategoryList, studySearchRouter };
 };
 
 export default useStudyList;

--- a/src/mocks/handlers/studyHandlers.ts
+++ b/src/mocks/handlers/studyHandlers.ts
@@ -1,11 +1,10 @@
 import { rest } from 'msw';
 import studyList from '@mocks/data/studyList.json';
 import studyInfo from '@mocks/data/studyInfo.json';
-import { CONFIG } from '@config';
 
 export const studyHandlers = [
   // 검색어로 스터디 조회
-  rest.get(`${CONFIG.BASE_URL}/api/v1/studies`, (req, res, ctx) => {
+  rest.get(`/api/v1/studies`, (req, res, ctx) => {
     const PAGINATE_UNIT = 12;
     const keyword = String(req.url.searchParams.get('keyword'));
     const page = Number(req.url.searchParams.get('page'));
@@ -19,6 +18,7 @@ export const studyHandlers = [
     );
     const paginatedStudies = findByKeyword.map((study, idx) => ({
       ...study,
+      id: PAGINATE_UNIT * (page - 1) + 1 + idx,
       title: study.title + `${page}`,
     }));
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,8 +8,10 @@ import tw from 'tailwind-styled-components';
 import Lottie from 'lottie-react';
 import animation from '@public/animation/main.json';
 import { categories } from '@constants/categories';
+import useStudyList from '@hooks/useStudyList';
 
 const Home = () => {
+  const { studySearchRouter } = useStudyList();
   const [keyword, setKeyword] = useState('');
   const router = useRouter();
 
@@ -21,7 +23,8 @@ const Home = () => {
     if (!(e.target instanceof HTMLImageElement)) return;
 
     if (!keyword) router.push('/search');
-    else if (keyword.startsWith('#')) router.push(`/search?tag=${keyword}`);
+    else if (keyword.startsWith('#'))
+      router.push(`/search?tags=${keyword.replace('#', '')}`);
     else router.push(`/search?post_title=${keyword}&study_name=${keyword}`);
   };
 
@@ -30,7 +33,8 @@ const Home = () => {
 
     if (e.key === 'Enter') {
       if (!keyword) router.push('/search');
-      else if (keyword.startsWith('#')) router.push(`/search?tag=${keyword}`);
+      else if (keyword.startsWith('#'))
+        router.push(`/search?tags=${keyword.replace('#', '')}`);
       else router.push(`/search?post_title=${keyword}&study_name=${keyword}`);
     }
   };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,8 +18,10 @@ const Home = () => {
   };
 
   const handleSearchClick = (e: React.MouseEvent<HTMLImageElement>) => {
-    if (!(e.target instanceof HTMLImageElement) || !keyword) return;
-    if (keyword.includes('#')) router.push(`/search?tag=${keyword}`);
+    if (!(e.target instanceof HTMLImageElement)) return;
+
+    if (!keyword) router.push('/search');
+    else if (keyword.includes('#')) router.push(`/search?tag=${keyword}`);
     else router.push(`/search?post_title=${keyword}&study_name=${keyword}`);
   };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,7 +21,7 @@ const Home = () => {
     if (!(e.target instanceof HTMLImageElement)) return;
 
     if (!keyword) router.push('/search');
-    else if (keyword.includes('#')) router.push(`/search?tag=${keyword}`);
+    else if (keyword.startsWith('#')) router.push(`/search?tag=${keyword}`);
     else router.push(`/search?post_title=${keyword}&study_name=${keyword}`);
   };
 
@@ -30,7 +30,7 @@ const Home = () => {
 
     if (e.key === 'Enter') {
       if (!keyword) router.push('/search');
-      else if (keyword.includes('#')) router.push(`/search?tag=${keyword}`);
+      else if (keyword.startsWith('#')) router.push(`/search?tag=${keyword}`);
       else router.push(`/search?post_title=${keyword}&study_name=${keyword}`);
     }
   };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,7 +26,7 @@ const Home = () => {
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (!(e.target instanceof HTMLInputElement) || !keyword) return;
+    if (!(e.target instanceof HTMLInputElement)) return;
 
     if (e.key === 'Enter') {
       if (!keyword) router.push('/search');

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,9 +18,10 @@ const Home = () => {
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (!(e.target instanceof HTMLInputElement)) return;
+    if (!(e.target instanceof HTMLInputElement) || !keyword) return;
     if (e.key === 'Enter') {
-      router.push(`/search?keyword=${keyword}`);
+      if (keyword.includes('#')) router.push(`/search?tag=${keyword}`);
+      else router.push(`/search?post_title=${keyword}&study_name=${keyword}`);
     }
   };
 
@@ -63,7 +64,7 @@ const Home = () => {
       img: 'https://github.com/crescenders/crescendo-frontend/assets/87893624/7c2fdee4-de2f-4fef-80c6-02e51e0715ac',
       title: '테스트 타이틀 4',
       studyName: '테스트 스터디명 4',
-      writer: 'Lami4',
+      writer: 'Lami   4',
       participant: 3,
       personnel: 6,
       tags: ['태그1', '태그2', '태그3'],
@@ -97,10 +98,12 @@ const Home = () => {
               />
             </Link>
           </div>
-          <div className="flex h-[28px] w-[215px] gap-3">
-            <Tag>#React</Tag>
-            <Tag>#Django</Tag>
-            <Tag>#Java</Tag>
+          <div className="flex h-[28px] w-[215px] cursor-pointer gap-3">
+            <Tag onClick={() => router.push(`/search?tags=React`)}>#React</Tag>
+            <Tag onClick={() => router.push(`/search?tags=Django`)}>
+              #Django
+            </Tag>
+            <Tag onClick={() => router.push(`/search?tags=Java`)}>#Java</Tag>
           </div>
         </div>
         <div className="h-[280px] w-[300px] ">
@@ -135,11 +138,11 @@ const Home = () => {
               key={id}
               path={`/post/${id}`}
               size="big"
-              isCanApply={true}
+              isClosed={true}
               img={img}
               title={title}
               studyName={studyName}
-              writer={writer}
+              writer={[]}
               participant={participant}
               personnel={personnel}
               tags={tags}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,8 +27,10 @@ const Home = () => {
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!(e.target instanceof HTMLInputElement) || !keyword) return;
+
     if (e.key === 'Enter') {
-      if (keyword.includes('#')) router.push(`/search?tag=${keyword}`);
+      if (!keyword) router.push('/search');
+      else if (keyword.includes('#')) router.push(`/search?tag=${keyword}`);
       else router.push(`/search?post_title=${keyword}&study_name=${keyword}`);
     }
   };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,6 +17,12 @@ const Home = () => {
     setKeyword(e.target.value);
   };
 
+  const handleSearchClick = (e: React.MouseEvent<HTMLImageElement>) => {
+    if (!(e.target instanceof HTMLImageElement) || !keyword) return;
+    if (keyword.includes('#')) router.push(`/search?tag=${keyword}`);
+    else router.push(`/search?post_title=${keyword}&study_name=${keyword}`);
+  };
+
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!(e.target instanceof HTMLInputElement) || !keyword) return;
     if (e.key === 'Enter') {
@@ -88,15 +94,14 @@ const Home = () => {
               placeholder="제목, 스터디명 또는 태그를 검색해주세요."
               className="h-[40px] w-[368px] rounded-xl bg-white py-[10px] pl-[12px] pr-[32px] focus:outline-none"
             />
-            <Link href={`/search?keyword=${keyword}`}>
-              <Image
-                src={'/svg/search_icon.svg'}
-                width={16}
-                height={16}
-                alt="searchIcon"
-                className="absolute bottom-[13px] right-[12px] cursor-pointer"
-              />
-            </Link>
+            <Image
+              src={'/svg/search_icon.svg'}
+              width={16}
+              height={16}
+              alt="searchIcon"
+              className="absolute bottom-[13px] right-[12px] cursor-pointer"
+              onClick={handleSearchClick}
+            />
           </div>
           <div className="flex h-[28px] w-[215px] cursor-pointer gap-3">
             <Tag onClick={() => router.push(`/search?tags=React`)}>#React</Tag>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -7,32 +7,125 @@ import {
   SORT_OBJ,
   SortStateType,
 } from '@constants/search';
-import { Suspense, useState } from 'react';
+import { Suspense, useRef, useState } from 'react';
 import tw from 'tailwind-styled-components';
 import StudyListSkeleton from '@components/skeleton/StudyListSkeleton';
+import Input from '@components/common/Input';
+import Image from 'next/image';
+import { categories } from '@constants/categories';
+import { useRouter } from 'next/router';
+import useStudyList from '@hooks/useStudyList';
 
 const Search = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { handleCategoryList } = useStudyList();
   const [isOpen, setIsOpen] = useState<SortStateType>(SORT_OBJ);
   const [leftValue, setLeftValue] = useState<string>('최신순');
   const [rightValue, setRightValue] = useState<string>('모집중');
 
+  const router = useRouter();
+
+  const handleSearchClick = () => {
+    if (!inputRef.current) return;
+    const { value } = inputRef.current;
+
+    if (value.split('')[0] === '#') {
+      router.replace({
+        pathname: router.pathname,
+        query: {
+          ...router.query,
+          tags: value.replace('#', ''),
+        },
+      });
+    } else
+      router.replace({
+        pathname: router.pathname,
+        query: {
+          ...router.query,
+          post_title: value,
+          study_title: value,
+        },
+      });
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!(e.target instanceof HTMLInputElement) || !inputRef.current) return;
+    const { value } = inputRef.current;
+
+    if (e.key === 'Enter') {
+      if (value.split('')[0] === '#')
+        router.replace({
+          pathname: router.pathname,
+          query: {
+            ...router.query,
+            tags: value.replace('#', ''),
+          },
+        });
+      else
+        router.replace({
+          pathname: router.pathname,
+          query: {
+            ...router.query,
+            post_title: value,
+            study_title: value,
+          },
+        });
+    }
+  };
+
   return (
     <PageLayout>
-      <div className="ml-[143px] mt-[150px] flex gap-x-2">
-        <SelectBox
-          options={LEFT_SELECT_OPTION}
-          value={leftValue}
-          setValue={setLeftValue}
-          isOpen={isOpen}
-          setIsOpen={setIsOpen}
-        />
-        <SelectBox
-          options={RIGHT_SELECT_OPTION}
-          value={rightValue}
-          setValue={setRightValue}
-          isOpen={isOpen}
-          setIsOpen={setIsOpen}
-        />
+      <div className="flex justify-center">
+        <div className="mt-[150px] flex items-center gap-x-2">
+          <SelectBox
+            options={LEFT_SELECT_OPTION}
+            value={leftValue}
+            setValue={setLeftValue}
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+          />
+          <SelectBox
+            options={RIGHT_SELECT_OPTION}
+            value={rightValue}
+            setValue={setRightValue}
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+          />
+          <Input
+            id="search-bar"
+            type="text"
+            variant="middle"
+            placeholder="제목, 스터디명 또는 태그를 검색해주세요."
+            className="w-[500px] text-14"
+            ref={inputRef}
+            defaultValue={router.query.study_title || router.query.post_title}
+            onKeyDown={onKeyDown}
+          />
+          <Image
+            src={'/svg/search_icon.svg'}
+            width={16}
+            height={16}
+            alt="searchIcon"
+            className="relative right-10 cursor-pointer"
+            onClick={handleSearchClick}
+          />
+        </div>
+      </div>
+      <div className="flex justify-center">
+        <ul className="mt-4 flex items-center gap-x-2">
+          {[{ name: 'All', id: 0 }, ...categories].map(({ id, name }) => (
+            <CategoryBox
+              key={id}
+              className={`${
+                router.query.categories?.includes(name) &&
+                'border-[#8266FF] text-[#8266FF]'
+              }`}
+              onClick={() => handleCategoryList(name)}
+            >
+              {name}
+            </CategoryBox>
+          ))}
+        </ul>
       </div>
       <StudyListContainer>
         <Suspense fallback={<StudyListSkeleton />}>
@@ -46,10 +139,28 @@ const Search = () => {
 export default Search;
 
 const StudyListContainer = tw.div`
-  mb-8
   mt-[100px]
-  flex
-  flex-wrap
-  justify-center
+  grid
+  grid-cols-4
+  items-center
   gap-8
+  px-2
+  pb-8
+`;
+
+const CategoryBox = tw.li`
+  flex
+  h-fit
+  w-fit
+  cursor-pointer
+  list-none
+  items-center
+  justify-center
+  rounded-[7px]
+  border-[1.5px]
+  border-[#EAEAEB]
+  bg-white
+  px-4
+  py-2
+  text-[14px]
 `;

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -18,36 +18,18 @@ import useStudyList from '@hooks/useStudyList';
 
 const Search = () => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const { handleCategoryList } = useStudyList();
+  const { handleCategoryList, studySearchRouter } = useStudyList();
   const [isOpen, setIsOpen] = useState<SortStateType>(SORT_OBJ);
   const [leftValue, setLeftValue] = useState<string>('최신순');
   const [rightValue, setRightValue] = useState<string>('모집중');
 
   const router = useRouter();
-  const { pathname } = router;
 
   const handleSearchClick = () => {
     if (!inputRef.current) return;
     const { value } = inputRef.current;
 
-    if (value === '') router.replace(pathname);
-    else if (value.split('')[0] === '#')
-      router.replace({
-        pathname: pathname,
-        query: {
-          ...router.query,
-          tags: value.replace('#', ''),
-        },
-      });
-    else
-      router.replace({
-        pathname: pathname,
-        query: {
-          ...router.query,
-          post_title: value,
-          study_title: value,
-        },
-      });
+    studySearchRouter(value);
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -55,24 +37,7 @@ const Search = () => {
     const { value } = inputRef.current;
 
     if (e.key === 'Enter') {
-      if (value === '') router.replace(pathname);
-      else if (value.split('')[0] === '#')
-        router.replace({
-          pathname: pathname,
-          query: {
-            ...router.query,
-            tags: value.replace('#', ''),
-          },
-        });
-      else
-        router.replace({
-          pathname: pathname,
-          query: {
-            ...router.query,
-            post_title: value,
-            study_title: value,
-          },
-        });
+      studySearchRouter(value);
     }
   };
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -7,7 +7,7 @@ import {
   SORT_OBJ,
   SortStateType,
 } from '@constants/search';
-import { Suspense, useRef, useState } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
 import tw from 'tailwind-styled-components';
 import StudyListSkeleton from '@components/skeleton/StudyListSkeleton';
 import Input from '@components/common/Input';
@@ -22,6 +22,7 @@ const Search = () => {
   const [isOpen, setIsOpen] = useState<SortStateType>(SORT_OBJ);
   const [leftValue, setLeftValue] = useState<string>('최신순');
   const [rightValue, setRightValue] = useState<string>('모집중');
+  const [queryParam, setQueryParam] = useState<string>('created_at');
 
   const router = useRouter();
   const { pathname } = router;
@@ -76,6 +77,16 @@ const Search = () => {
     }
   };
 
+  useEffect(() => {
+    router.replace({
+      pathname: pathname,
+      query: {
+        ...router.query,
+        ordering: queryParam,
+      },
+    });
+  }, [queryParam]);
+
   return (
     <PageLayout>
       <div className="flex justify-center">
@@ -86,6 +97,8 @@ const Search = () => {
             setValue={setLeftValue}
             isOpen={isOpen}
             setIsOpen={setIsOpen}
+            queryParam={queryParam}
+            setQueryParam={setQueryParam}
           />
           <SelectBox
             options={RIGHT_SELECT_OPTION}

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -24,22 +24,24 @@ const Search = () => {
   const [rightValue, setRightValue] = useState<string>('모집중');
 
   const router = useRouter();
+  const { pathname } = router;
 
   const handleSearchClick = () => {
     if (!inputRef.current) return;
     const { value } = inputRef.current;
 
-    if (value.split('')[0] === '#') {
+    if (value === '') router.replace(pathname);
+    else if (value.split('')[0] === '#')
       router.replace({
-        pathname: router.pathname,
+        pathname: pathname,
         query: {
           ...router.query,
           tags: value.replace('#', ''),
         },
       });
-    } else
+    else
       router.replace({
-        pathname: router.pathname,
+        pathname: pathname,
         query: {
           ...router.query,
           post_title: value,
@@ -53,9 +55,10 @@ const Search = () => {
     const { value } = inputRef.current;
 
     if (e.key === 'Enter') {
-      if (value.split('')[0] === '#')
+      if (value === '') router.replace(pathname);
+      else if (value.split('')[0] === '#')
         router.replace({
-          pathname: router.pathname,
+          pathname: pathname,
           query: {
             ...router.query,
             tags: value.replace('#', ''),
@@ -63,7 +66,7 @@ const Search = () => {
         });
       else
         router.replace({
-          pathname: router.pathname,
+          pathname: pathname,
           query: {
             ...router.query,
             post_title: value,

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -22,7 +22,6 @@ const Search = () => {
   const [isOpen, setIsOpen] = useState<SortStateType>(SORT_OBJ);
   const [leftValue, setLeftValue] = useState<string>('최신순');
   const [rightValue, setRightValue] = useState<string>('모집중');
-  const [queryParam, setQueryParam] = useState<string>('created_at');
 
   const router = useRouter();
   const { pathname } = router;
@@ -77,16 +76,6 @@ const Search = () => {
     }
   };
 
-  useEffect(() => {
-    router.replace({
-      pathname: pathname,
-      query: {
-        ...router.query,
-        ordering: queryParam,
-      },
-    });
-  }, [queryParam]);
-
   return (
     <PageLayout>
       <div className="flex justify-center">
@@ -97,8 +86,6 @@ const Search = () => {
             setValue={setLeftValue}
             isOpen={isOpen}
             setIsOpen={setIsOpen}
-            queryParam={queryParam}
-            setQueryParam={setQueryParam}
           />
           <SelectBox
             options={RIGHT_SELECT_OPTION}


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
 - close #93 
 - close #92 
<!--수정/추가한 작업 내용을 설명해주세요.-->

## 🧑‍💻 PR 세부 내용
- 메인페이지 검색 기능 구현
  - 태그 입력 시 태그 쿼리 파라미터만, 일반 문자열 입력 시 `post_title`, `study_name` 쿼리 파라미터가 동시에 적용됩니다.
- 검색 페이지 필터링 기능 구현
<!-- 세부 내용을 설명해주세요.-->

## 리뷰어에게
양이 좀 많아서 비즈니스 로직 위주로 확인해주시면 될 것 같습니다 ..

- 메인페이지 & 검색페이지 모두 검색 문자열을 입력하지 않았다면 검색 페이지로 이동하거나 쿼리값을 모두 제거하는 방향으로 구현해놓았습니다.
- ordering, is_closed 쿼리 파라미터를 적용 안 했을 경우 기본값으로 각각 최신순 / 모집중 + 모집완료로 응답이 오는데, 오른쪽의 SelectBox 기본값은 모집중이므로 모순이 있어서 의논해봐야할 것 같습니다.

이 부분에 대해서 의견 있으시면 주세요.

버그가 발생하거나 개선해야 할 부분 의견 주시면 감사하겠습니다. 잘 부탁드립니다!

## 📸 스크린샷 or GIF
![화면 기록 2023-09-23 오후 8 04 18](https://github.com/crescenders/crescendo-frontend/assets/48711263/ef03bc30-0637-4284-8030-7df566b68f22)
<!--스크린샷 또는 GIF를 첨부해주세요.-->
