### PR TITLE
[CRES-89] 메인페이지 랜덤 스터디 목록 구현

### DIFF
--- a/src/components/home/HomeStudyList.tsx
+++ b/src/components/home/HomeStudyList.tsx
@@ -1,0 +1,55 @@
+import Card from '@components/common/Card';
+import { useGetRandomStudyGroupList } from '@hooks/queries/useGetStudy';
+import tw from 'tailwind-styled-components';
+
+const HomeStudyList = () => {
+  const { data } = useGetRandomStudyGroupList();
+
+  return (
+    <StudyListContainer>
+      {data?.results
+        .slice(0, 4)
+        .map(
+          ({
+            uuid,
+            head_image,
+            leaders,
+            post_title,
+            study_name,
+            is_closed,
+            tags,
+            current_member_count,
+            member_limit,
+            until_deadline,
+          }) => (
+            <Card
+              path={`/study/detail/${uuid}`}
+              key={uuid}
+              size="big"
+              title={post_title}
+              studyName={study_name}
+              writer={leaders[0] && leaders[0].username}
+              tags={tags}
+              isClosed={is_closed}
+              img={head_image}
+              participant={current_member_count}
+              personnel={member_limit}
+              deadline={until_deadline}
+            />
+          ),
+        )}
+    </StudyListContainer>
+  );
+};
+
+export default HomeStudyList;
+
+const StudyListContainer = tw.div`
+  flex
+  w-full
+  flex-wrap
+  items-center
+  justify-center
+  gap-8
+  pb-8
+`;

--- a/src/components/search/StudyList.tsx
+++ b/src/components/search/StudyList.tsx
@@ -78,7 +78,6 @@ const StudyList = () => {
 export default StudyList;
 
 const StudyListContainer = tw.div`
-  mt-10
   flex
   w-full
   flex-wrap

--- a/src/components/search/StudyList.tsx
+++ b/src/components/search/StudyList.tsx
@@ -5,6 +5,7 @@ import useIntersection from '@hooks/useIntersection';
 import StudyListSkeleton from '@components/skeleton/StudyListSkeleton';
 import Card from '@components/common/Card';
 import NotFoundStudyList from '@components/search/NotFoundStudyList';
+import tw from 'tailwind-styled-components';
 
 const StudyList = () => {
   const router = useRouter();
@@ -25,47 +26,49 @@ const StudyList = () => {
 
   return (
     <>
-      {studies.pages.flatMap((page) => page.results).length > 0 ? (
-        studies.pages.flatMap((pages) =>
-          pages.results.map(
-            ({
-              uuid,
-              head_image,
-              leaders,
-              post_title,
-              study_name,
-              is_closed,
-              tags,
-              current_member_count,
-              member_limit,
-              until_deadline,
-            }) => (
-              <Card
-                path={`/study/detail/${uuid}`}
-                key={uuid}
-                size="big"
-                title={post_title}
-                studyName={study_name}
-                writer={leaders[0] && leaders[0].username} // admin 페이지에서 생성한 게시물은 leaders가 없다. 추후 수정 필요
-                tags={tags}
-                isClosed={is_closed}
-                img={head_image}
-                participant={current_member_count}
-                personnel={member_limit}
-                deadline={until_deadline}
-              />
+      <StudyListContainer>
+        {studies.pages.flatMap((page) => page.results).length > 0 ? (
+          studies.pages.flatMap((pages) =>
+            pages.results.map(
+              ({
+                uuid,
+                head_image,
+                leaders,
+                post_title,
+                study_name,
+                is_closed,
+                tags,
+                current_member_count,
+                member_limit,
+                until_deadline,
+              }) => (
+                <Card
+                  path={`/study/detail/${uuid}`}
+                  key={uuid}
+                  size="big"
+                  title={post_title}
+                  studyName={study_name}
+                  writer={leaders[0] && leaders[0].username} // admin 페이지에서 생성한 게시물은 leaders가 없다. 추후 수정 필요
+                  tags={tags}
+                  isClosed={is_closed}
+                  img={head_image}
+                  participant={current_member_count}
+                  personnel={member_limit}
+                  deadline={until_deadline}
+                />
+              ),
             ),
-          ),
-        )
-      ) : (
-        <NotFoundStudyList
-          keyword={
-            (router.query.post_title as string) ||
-            (router.query.study_title as string) ||
-            (router.query.tags as string)
-          }
-        />
-      )}
+          )
+        ) : (
+          <NotFoundStudyList
+            keyword={
+              (router.query.post_title as string) ||
+              (router.query.study_title as string) ||
+              (router.query.tags as string)
+            }
+          />
+        )}
+      </StudyListContainer>
       {isFetching && <StudyListSkeleton />}
       <div ref={targetRef} />
     </>
@@ -73,3 +76,14 @@ const StudyList = () => {
 };
 
 export default StudyList;
+
+const StudyListContainer = tw.div`
+  mt-10
+  flex
+  w-full
+  flex-wrap
+  items-center
+  justify-center
+  gap-8
+  pb-8
+`;

--- a/src/components/skeleton/StudyListSkeleton.tsx
+++ b/src/components/skeleton/StudyListSkeleton.tsx
@@ -1,8 +1,8 @@
 const StudyListSkeleton = () => {
-  const array = Array.from({ length: 12 }, (_, i) => i);
+  const array = Array.from({ length: 8 }, (_, i) => i);
 
   return (
-    <>
+    <div className="flex flex-wrap items-center justify-center gap-8">
       {array.map((_, i) => (
         <li
           key={i}
@@ -22,7 +22,7 @@ const StudyListSkeleton = () => {
           </div>
         </li>
       ))}
-    </>
+    </div>
   );
 };
 

--- a/src/hooks/mutations/usePutUser.ts
+++ b/src/hooks/mutations/usePutUser.ts
@@ -14,6 +14,10 @@ export const usePutUser = () => {
       setUserInfo((info) => {
         return { ...info, username: nickname };
       });
+      showToast({
+        type: 'success',
+        message: '프로필을 저장했어요.',
+      });
     },
     onError: () => {
       showToast({

--- a/src/hooks/queries/useGetStudy.ts
+++ b/src/hooks/queries/useGetStudy.ts
@@ -23,6 +23,13 @@ export const useGetStudyGroupList = (params = '') => {
   });
 };
 
+export const useGetRandomStudyGroupList = () => {
+  return useQuery({
+    queryKey: ['useGetRandomStudyGroupList'],
+    queryFn: () => studyApi.getStudyGroupList('?random=true'),
+  });
+};
+
 export const useGetStudyDetail = (id: string) => {
   return useSuspenseQuery({
     queryKey: ['useGetStudyDetail', id],

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import Card from '@components/common/Card';
 import PageLayout from '@components/common/PageLayout';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -8,10 +7,9 @@ import tw from 'tailwind-styled-components';
 import Lottie from 'lottie-react';
 import animation from '@public/animation/main.json';
 import { categories } from '@constants/categories';
-import useStudyList from '@hooks/useStudyList';
+import HomeStudyList from '@components/home/HomeStudyList';
 
 const Home = () => {
-  const { studySearchRouter } = useStudyList();
   const [keyword, setKeyword] = useState('');
   const router = useRouter();
 
@@ -38,53 +36,6 @@ const Home = () => {
       else router.push(`/search?post_title=${keyword}&study_name=${keyword}`);
     }
   };
-
-  const DUMMY_DATALIST = [
-    {
-      id: 1,
-      img: 'https://github.com/crescenders/crescendo-frontend/assets/87893624/d458744c-54b6-4018-9de5-ba354e6da407',
-      title: '테스트 타이틀 1',
-      studyName: '테스트 스터디명 1',
-      writer: 'Lami',
-      participant: 3,
-      personnel: 5,
-      tags: ['태그1', '태그2', '태그3'],
-      startDate: '2023.06.04',
-    },
-    {
-      id: 2,
-      img: 'https://github.com/crescenders/crescendo-frontend/assets/87893624/777979ee-45f3-4f00-88c3-cb32119249fe',
-      title: '테스트 타이틀 2',
-      studyName: '테스트 스터디명 2',
-      writer: 'Lami2',
-      participant: 4,
-      personnel: 10,
-      tags: ['태그1', '태그2', '태그3'],
-      startDate: '2023.06.12',
-    },
-    {
-      id: 3,
-      img: 'https://github.com/crescenders/crescendo-frontend/assets/87893624/396933ec-8d20-4faf-9412-f18e06332558',
-      title: '테스트 타이틀 3',
-      studyName: '테스트 스터디명 3',
-      writer: 'Lami3',
-      participant: 2,
-      personnel: 8,
-      tags: ['태그1', '태그2', '태그3'],
-      startDate: '2023.06.05',
-    },
-    {
-      id: 4,
-      img: 'https://github.com/crescenders/crescendo-frontend/assets/87893624/7c2fdee4-de2f-4fef-80c6-02e51e0715ac',
-      title: '테스트 타이틀 4',
-      studyName: '테스트 스터디명 4',
-      writer: 'Lami   4',
-      participant: 3,
-      personnel: 6,
-      tags: ['태그1', '태그2', '태그3'],
-      startDate: '2023.06.20',
-    },
-  ];
 
   return (
     <PageLayout>
@@ -134,36 +85,7 @@ const Home = () => {
             ),
         )}
       </div>
-      <div className="flex justify-center gap-[41px]">
-        {DUMMY_DATALIST.map(
-          ({
-            id,
-            img,
-            title,
-            studyName,
-            writer,
-            participant,
-            personnel,
-            tags,
-            startDate,
-          }) => (
-            <Card
-              key={id}
-              path={`/post/${id}`}
-              size="big"
-              isClosed={true}
-              img={img}
-              title={title}
-              studyName={studyName}
-              writer={''}
-              participant={participant}
-              personnel={personnel}
-              tags={tags}
-              startDate={startDate as string}
-            />
-          ),
-        )}
-      </div>
+      <HomeStudyList />
     </PageLayout>
   );
 };
@@ -191,4 +113,14 @@ const Category = tw(Link)`
   rounded-[19px]
   border-[#C4A9D8]
   hover:border
+`;
+
+const StudyListContainer = tw.div`
+  flex
+  w-full
+  flex-wrap
+  items-center
+  justify-center
+  gap-8
+  pb-8
 `;

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,9 +1,7 @@
 import authApi from '@apis/auth/authApi';
 import userApi from '@apis/user/userApi';
-import PageLayout from '@components/common/PageLayout';
 import { CredentialResponse } from '@components/modal/LoginModal';
 import { CONFIG } from '@config';
-import useModal from '@hooks/useModal';
 import useScript from '@hooks/useScript';
 import useUser from '@hooks/useUser';
 import { userState } from '@recoil/auth';
@@ -57,33 +55,26 @@ const Login = () => {
   }, []);
 
   return (
-    <PageLayout>
-      <div className="flex h-full flex-col items-center justify-center">
+    <div className="flex h-full w-full flex-col items-center justify-center">
+      <Image src="/svg/logo_symbol_small.svg" width={203} height={130} alt="" />
+      <span className="mt-[85px] whitespace-pre-wrap text-center text-[20px] font-bold leading-9 tracking-tight text-[#4f4f4f]">
+        {'로그인을 하여 스터디에 \n 참여해보세요!'}
+      </span>
+      <div ref={googleSignInButton} className="hidden" />
+      <LoginButton onClick={handleClickButton}>
         <Image
-          src="/svg/logo_symbol_small.svg"
-          width={203}
-          height={130}
-          alt=""
+          className="absolute left-[23px]"
+          src={'/svg/google_symbol.svg'}
+          width={24}
+          height={24}
+          alt="logo"
         />
-        <span className="mt-[85px] whitespace-pre-wrap text-center text-[20px] font-bold leading-9 tracking-tight text-[#4f4f4f]">
-          {'로그인을 하여 스터디에 \n 참여해보세요!'}
-        </span>
-        <div ref={googleSignInButton} className="hidden" />
-        <LoginButton onClick={handleClickButton}>
-          <Image
-            className="absolute left-[23px]"
-            src={'/svg/google_symbol.svg'}
-            width={24}
-            height={24}
-            alt="logo"
-          />
-          <span className="text-18">Google 로그인</span>
-        </LoginButton>
-        <StartWithoutLogin onClick={() => router.back()}>
-          로그인 없이 이용하기
-        </StartWithoutLogin>
-      </div>
-    </PageLayout>
+        <span className="text-18">Google 로그인</span>
+      </LoginButton>
+      <StartWithoutLogin onClick={() => router.back()}>
+        로그인 없이 이용하기
+      </StartWithoutLogin>
+    </div>
   );
 };
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -81,7 +81,7 @@ const Search = () => {
           />
         </div>
       </div>
-      <div className="flex justify-center">
+      <div className="mb-10 flex justify-center">
         <ul className="mt-4 flex flex-wrap items-center gap-x-2 gap-y-3">
           {[{ name: 'All', id: 0 }, ...categories].map(({ id, name }) => (
             <CategoryBox
@@ -102,26 +102,14 @@ const Search = () => {
           ))}
         </ul>
       </div>
-      <StudyListContainer>
-        <Suspense fallback={<StudyListSkeleton />}>
-          <StudyList />
-        </Suspense>
-      </StudyListContainer>
+      <Suspense fallback={<StudyListSkeleton />}>
+        <StudyList />
+      </Suspense>
     </PageLayout>
   );
 };
 
 export default Search;
-
-const StudyListContainer = tw.div`
-  mt-[100px]
-  flex
-  flex-wrap
-  items-center
-  gap-8
-  px-2
-  pb-8
-`;
 
 const CategoryBox = tw.li`
   flex


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- close #112 
<!--수정/추가한 작업 내용을 설명해주세요.-->

## 🧑‍💻 PR 세부 내용
- 메인페이지 랜덤 스터디 목록 구현
- 검색 결과의 StudyList가 중앙 정렬되어 있지 않은 문제를 해결하고 레이아웃과 디자인 조정
- 로그인 페이지의 PageLayout 제거
- usePutUser onSuccess 콜백 함수의 누락된 토스트 메시지 추가
<!-- 세부 내용을 설명해주세요.-->

## 리뷰어에게
임시로 일단 메인페이지의 랜덤스터디 적용해놓았는데 디자인과 API 스펙 사이에 애매한 부분이 있어서 스크롤 방식으로 적용할건지 딱 4개만 보여주는건지 의논해봐야될 것 같습니당
## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
