### PR TITLE
[CRES-91] 내가 맡은 스터디 페이지 구현

### DIFF
--- a/src/apis/study/studyApi.ts
+++ b/src/apis/study/studyApi.ts
@@ -32,6 +32,12 @@ const studyApi = {
   deleteStudy: async (id: string): Promise<void> => {
     return await instance.delete(`/api/v1/studygroup/studies/${id}/`);
   },
+  getMyStudyGroupList: async (params: string): Promise<StudyList> => {
+    const { data } = await instance.get(
+      `/api/v1/auth/profiles/me/studies?${params}`,
+    );
+    return data;
+  },
 };
 
 export default studyApi;

--- a/src/components/manage/MyStudyList.tsx
+++ b/src/components/manage/MyStudyList.tsx
@@ -26,13 +26,13 @@ const MyStudyList = () => {
           ({ uuid, post_title, categories, member_limit, is_closed }) => (
             <OpenStudyCard
               key={uuid}
-              id={uuid}
-              title={post_title}
-              category={categories}
-              personnel={member_limit}
+              uuid={uuid}
+              postTitle={post_title}
+              categories={categories}
+              memberLimit={member_limit}
               isClosed={is_closed}
-              study_period="YYYY-MM-DD - YYYY-MM-DD"
-              recruitment_period="YYYY-MM-DD - YYYY-MM-DD"
+              studyPeriod="YYYY-MM-DD - YYYY-MM-DD"
+              recruitmentPeriod="YYYY-MM-DD - YYYY-MM-DD"
             />
           ),
         ),

--- a/src/components/manage/MyStudyList.tsx
+++ b/src/components/manage/MyStudyList.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+import OpenStudyCard from '@components/manage/OpenStudyCard';
+import MyStudyListSkeleton from '@components/skeleton/MyStudyListSkeleton';
+import useIntersection from '@hooks/useIntersection';
+import { useGetMyStudyGroupList } from '@hooks/queries/useGetStudy';
+
+const MyStudyList = () => {
+  const { targetRef, isIntersecting } = useIntersection({ threshold: 0.4 });
+  const {
+    data: studies,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+  } = useGetMyStudyGroupList('as_leader');
+
+  useEffect(() => {
+    if (isIntersecting && hasNextPage && !isFetching) {
+      fetchNextPage();
+    }
+  }, [isIntersecting, isFetching]);
+
+  return studies.pages.flatMap((page) => page.results).length > 0 ? (
+    <>
+      {studies.pages.flatMap((pages) =>
+        pages.results.map(
+          ({ uuid, post_title, categories, member_limit, is_closed }) => (
+            <OpenStudyCard
+              key={uuid}
+              id={uuid}
+              title={post_title}
+              category={categories}
+              personnel={member_limit}
+              isClosed={is_closed}
+              study_period="YYYY-MM-DD - YYYY-MM-DD"
+              recruitment_period="YYYY-MM-DD - YYYY-MM-DD"
+            />
+          ),
+        ),
+      )}
+      {isFetching && <MyStudyListSkeleton />}
+      <div ref={targetRef} />
+    </>
+  ) : (
+    <div className="flex grow items-center justify-center ">
+      <span className="text-center text-[#8A8A8A]">
+        개설한 스터디가 없습니다. <br /> 새로운 스터디를 개설해보세요!
+      </span>
+    </div>
+  );
+};
+
+export default MyStudyList;

--- a/src/components/manage/OpenStudyCard.tsx
+++ b/src/components/manage/OpenStudyCard.tsx
@@ -3,6 +3,7 @@ import { useDeleteStudy } from '@hooks/mutations/useDeleteStudy';
 import useModal from '@hooks/useModal';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import tw from 'tailwind-styled-components';
 
 export type MyStudyListType = {
@@ -24,18 +25,19 @@ const OpenStudyCard = ({
   study_period,
   recruitment_period,
 }: MyStudyListType) => {
+  const router = useRouter();
   const { openModal, closeModal } = useModal();
   const { mutate: deleteStudy } = useDeleteStudy();
 
   return (
-    <StudyCard>
+    <StudyCard
+      onClick={() => router.push(`/study/manage/assignment/${id}`)}
+      className="cursor-pointer"
+    >
       <div className="flex w-[100%] justify-between gap-x-1">
-        <Link
-          href={`/study/manage/assignment/${id}`}
-          className="block shrink truncate"
-        >
-          <span className="whitespace-nowrap text-[17px]">{title}</span>
-        </Link>
+        <div className="shrink truncate whitespace-nowrap text-[17px]">
+          {title}
+        </div>
         <div className="mr-2 flex items-center gap-x-0.5">
           <Image src="/svg/person.svg" width={18} height={18} alt="인원" />
           <span className="text-12">{personnel}</span>
@@ -66,7 +68,8 @@ const OpenStudyCard = ({
           height={40}
           alt="삭제"
           className="cursor-pointer"
-          onClick={() =>
+          onClick={(e) => {
+            e.stopPropagation();
             openModal(
               <DeleteModal
                 handleClick={() => {
@@ -77,8 +80,8 @@ const OpenStudyCard = ({
                 firstText="삭제한 스터디는 복구할 수 없어요."
                 secondText="그래도 삭제를 진행하시겠어요?"
               />,
-            )
-          }
+            );
+          }}
         />
       </div>
     </StudyCard>

--- a/src/components/manage/OpenStudyCard.tsx
+++ b/src/components/manage/OpenStudyCard.tsx
@@ -1,14 +1,16 @@
 import DeleteModal from '@components/modal/DeleteModal';
+import { useDeleteStudy } from '@hooks/mutations/useDeleteStudy';
 import useModal from '@hooks/useModal';
 import Image from 'next/image';
 import Link from 'next/link';
 import tw from 'tailwind-styled-components';
 
 export type MyStudyListType = {
-  id: number;
+  id: string;
   title: string;
   category: string[];
   personnel: number;
+  isClosed: boolean;
   study_period: string;
   recruitment_period: string;
 };
@@ -18,34 +20,44 @@ const OpenStudyCard = ({
   title,
   category,
   personnel,
+  isClosed,
   study_period,
   recruitment_period,
 }: MyStudyListType) => {
-  const { openModal } = useModal();
+  const { openModal, closeModal } = useModal();
+  const { mutate: deleteStudy } = useDeleteStudy();
 
   return (
     <StudyCard>
-      <div className="flex justify-between">
-        <Link href={`/study/manage/assignment/${id}`}>
-          <span className="text-[17px]">{title}</span>
+      <div className="flex w-[100%] justify-between gap-x-1">
+        <Link
+          href={`/study/manage/assignment/${id}`}
+          className="block shrink truncate"
+        >
+          <span className="whitespace-nowrap text-[17px]">{title}</span>
         </Link>
-        <div className="flex items-center gap-x-0.5 mr-2">
+        <div className="mr-2 flex items-center gap-x-0.5">
           <Image src="/svg/person.svg" width={18} height={18} alt="인원" />
           <span className="text-12">{personnel}</span>
         </div>
       </div>
-      <div className="flex gap-x-2 text-12 mt-[11px]">
+      <div className="mt-[11px] flex gap-x-2 text-12 ">
         {category.map((category, idx) => (
           <span key={idx}>{category}</span>
         ))}
       </div>
-      <div className="flex justify-between items-center mt-11">
+      <div className="mt-11 flex items-center justify-between">
         <div className="flex flex-col">
           <span className="text-12 text-text-secondary">
             스터디 기간 {study_period}
           </span>
-          <span className="text-12 text-text-secondary">
-            모집 기간 {recruitment_period}
+          <span className="flex gap-x-2">
+            <span className="text-12 text-text-secondary">
+              모집 기간 {recruitment_period}
+            </span>
+            {isClosed && (
+              <span className="text-12 font-bold text-status-error">마감</span>
+            )}
           </span>
         </div>
         <Image
@@ -57,10 +69,13 @@ const OpenStudyCard = ({
           onClick={() =>
             openModal(
               <DeleteModal
-                handleClick={() => alert('삭제')}
+                handleClick={() => {
+                  deleteStudy(id);
+                  closeModal();
+                }}
                 title="스터디 삭제"
                 firstText="삭제한 스터디는 복구할 수 없어요."
-                secondText="삭제 진행하시겠어요?"
+                secondText="그래도 삭제를 진행하시겠어요?"
               />,
             )
           }
@@ -74,8 +89,11 @@ export default OpenStudyCard;
 
 const StudyCard = tw.div`
   shadow-studyCard
+  flex
   h-[171px]
   w-[445px]
+  flex-col
+  justify-between
   rounded-[20px]
   bg-white
   p-5

--- a/src/components/manage/OpenStudyCard.tsx
+++ b/src/components/manage/OpenStudyCard.tsx
@@ -7,23 +7,23 @@ import { useRouter } from 'next/router';
 import tw from 'tailwind-styled-components';
 
 export type MyStudyListType = {
-  id: string;
-  title: string;
-  category: string[];
-  personnel: number;
+  uuid: string;
+  postTitle: string;
+  categories: string[];
+  memberLimit: number;
   isClosed: boolean;
-  study_period: string;
-  recruitment_period: string;
+  studyPeriod: string;
+  recruitmentPeriod: string;
 };
 
 const OpenStudyCard = ({
-  id,
-  title,
-  category,
-  personnel,
+  uuid,
+  postTitle,
+  categories,
+  memberLimit,
   isClosed,
-  study_period,
-  recruitment_period,
+  studyPeriod,
+  recruitmentPeriod,
 }: MyStudyListType) => {
   const router = useRouter();
   const { openModal, closeModal } = useModal();
@@ -31,31 +31,31 @@ const OpenStudyCard = ({
 
   return (
     <StudyCard
-      onClick={() => router.push(`/study/manage/assignment/${id}`)}
+      onClick={() => router.push(`/study/manage/assignment/${uuid}`)}
       className="cursor-pointer"
     >
-      <div className="flex w-[100%] justify-between gap-x-1">
+      <div className="flex w-full justify-between gap-x-1">
         <div className="shrink truncate whitespace-nowrap text-[17px]">
-          {title}
+          {postTitle}
         </div>
         <div className="mr-2 flex items-center gap-x-0.5">
           <Image src="/svg/person.svg" width={18} height={18} alt="인원" />
-          <span className="text-12">{personnel}</span>
+          <span className="text-12">{memberLimit}</span>
         </div>
       </div>
       <div className="mt-[11px] flex gap-x-2 text-12 ">
-        {category.map((category, idx) => (
+        {categories.map((category, idx) => (
           <span key={idx}>{category}</span>
         ))}
       </div>
       <div className="mt-11 flex items-center justify-between">
         <div className="flex flex-col">
           <span className="text-12 text-text-secondary">
-            스터디 기간 {study_period}
+            스터디 기간 {studyPeriod}
           </span>
           <span className="flex gap-x-2">
             <span className="text-12 text-text-secondary">
-              모집 기간 {recruitment_period}
+              모집 기간 {recruitmentPeriod}
             </span>
             {isClosed && (
               <span className="text-12 font-bold text-status-error">마감</span>
@@ -73,7 +73,7 @@ const OpenStudyCard = ({
             openModal(
               <DeleteModal
                 handleClick={() => {
-                  deleteStudy(id);
+                  deleteStudy(uuid);
                   closeModal();
                 }}
                 title="스터디 삭제"

--- a/src/components/skeleton/MyStudyListSkeleton.tsx
+++ b/src/components/skeleton/MyStudyListSkeleton.tsx
@@ -1,0 +1,35 @@
+const MyStudyListSkeleton = () => {
+  const array = Array.from({ length: 8 }, (_, i) => i);
+
+  return (
+    <>
+      {array.map((_, i) => (
+        <div
+          key={i}
+          className="flex h-[171px] w-[445px] flex-col justify-between rounded-[20px] bg-white p-5 shadow-studyCard"
+        >
+          <div className="flex w-[100%] justify-between">
+            <div className="w-60 animate-skeleton-gradient rounded-sm" />
+            <div className="mr-2 flex items-center gap-x-0.5">
+              <div className="h-[17px] w-[30px] animate-skeleton-gradient rounded-sm" />
+            </div>
+          </div>
+          <div className="mt-[11px] flex gap-x-2">
+            <div className="h-[17px] w-14 animate-skeleton-gradient rounded-sm" />
+            <div className="h-[17px] w-14 animate-skeleton-gradient rounded-sm" />
+            <div className="h-[17px] w-14 animate-skeleton-gradient rounded-sm" />
+          </div>
+          <div className="mt-11 flex items-center justify-between">
+            <div className="flex flex-col justify-between gap-y-1">
+              <div className="h-[12px] w-40 animate-skeleton-gradient rounded-sm" />
+              <div className="h-[12px] w-36 animate-skeleton-gradient rounded-sm" />
+            </div>
+            <div className="h-[35px] w-[35px] animate-skeleton-gradient rounded-full" />
+          </div>
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default MyStudyListSkeleton;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,7 +2,7 @@ export const REQUIRED = '*' as const;
 
 export const NAVIGATE_LIST = [
   { id: 1, text: '마이페이지', path: '/mypage' },
-  { id: 2, text: '스터디 관리', path: '/studymanage' },
+  { id: 2, text: '스터디 관리', path: '/study/manage' },
   { id: 3, text: '정보 수정', path: '/mypage/edit' },
   { id: 4, text: '로그아웃', path: '' },
 ] as const;

--- a/src/hooks/mutations/useDeleteStudy.ts
+++ b/src/hooks/mutations/useDeleteStudy.ts
@@ -1,13 +1,15 @@
 import studyApi from '@apis/study/studyApi';
 import useToast from '@hooks/useToast';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useDeleteStudy = () => {
   const { showToast } = useToast();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (id: string) => studyApi.deleteStudy(id),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['useGetMyStudyGroupList'] });
       showToast({
         type: 'success',
         message: '성공적으로 글을 삭제했어요.',

--- a/src/hooks/queries/useGetStudy.ts
+++ b/src/hooks/queries/useGetStudy.ts
@@ -45,11 +45,13 @@ export const useGetMyStudyGroupList = (filter: string) => {
   return useSuspenseInfiniteQuery({
     queryKey: ['useGetMyStudyGroupList', filter],
     queryFn: ({ pageParam }) => {
-      return studyApi.getMyStudyGroupList(pageParam);
+      return studyApi.getMyStudyGroupList(
+        `filter=${filter}&cursor=${pageParam}`,
+      );
     },
     initialPageParam: '',
     getNextPageParam: (lastPage) => {
-      return lastPage.next && lastPage.next.split('?')[1];
+      return lastPage.next && new URL(lastPage.next).searchParams.get('cursor');
     },
   });
 };

--- a/src/hooks/queries/useGetStudy.ts
+++ b/src/hooks/queries/useGetStudy.ts
@@ -40,3 +40,16 @@ export const useGetStudyDetailInStudyForm = (id: string) => {
     enabled: !!id,
   });
 };
+
+export const useGetMyStudyGroupList = (filter: string) => {
+  return useSuspenseInfiniteQuery({
+    queryKey: ['useGetMyStudyGroupList', filter],
+    queryFn: ({ pageParam }) => {
+      return studyApi.getMyStudyGroupList(pageParam);
+    },
+    initialPageParam: '',
+    getNextPageParam: (lastPage) => {
+      return lastPage.next && lastPage.next.split('?')[1];
+    },
+  });
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,5 +8,5 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/mypage/:path*', '/study/create'],
+  matcher: ['/mypage/:path*', '/study/create', '/study/manage/:path*'],
 };

--- a/src/pages/study/manage/index.tsx
+++ b/src/pages/study/manage/index.tsx
@@ -1,103 +1,29 @@
 import Button from '@components/common/Button';
 import PageLayout from '@components/common/PageLayout';
-import OpenStudyCard, {
-  MyStudyListType,
-} from '@components/manage/OpenStudyCard';
+import MyStudyList from '@components/manage/MyStudyList';
+import MyStudyListSkeleton from '@components/skeleton/MyStudyListSkeleton';
+import { useRouter } from 'next/router';
+import { Suspense } from 'react';
 import tw from 'tailwind-styled-components';
 
-const MY_STUDY_LIST: MyStudyListType[] = [
-  {
-    id: 1,
-    title: '스터디명스터디명스터디명스터디명',
-    category: ['Frontend', 'Backend', 'interview'],
-    personnel: 5,
-    study_period: '2023.01.01 - 2023.02.02',
-    recruitment_period: '2023.01.01 - 2023.02.02',
-  },
-  {
-    id: 2,
-    title: '스터디명스터디명스터디명스터디명',
-    category: ['Frontend', 'Backend', 'interview'],
-    personnel: 5,
-    study_period: '2023.01.01 - 2023.02.02',
-    recruitment_period: '2023.01.01 - 2023.02.02',
-  },
-  {
-    id: 3,
-    title: '스터디명스터디명스터디명스터디명',
-    category: ['Frontend', 'Backend', 'interview'],
-    personnel: 5,
-    study_period: '2023.01.01 - 2023.02.02',
-    recruitment_period: '2023.01.01 - 2023.02.02',
-  },
-  {
-    id: 4,
-    title: '스터디명스터디명스터디명스터디명',
-    category: ['Frontend', 'Backend', 'interview'],
-    personnel: 5,
-    study_period: '2023.01.01 - 2023.02.02',
-    recruitment_period: '2023.01.01 - 2023.02.02',
-  },
-  {
-    id: 5,
-    title: '스터디명스터디명스터디명스터디명',
-    category: ['Frontend', 'Backend', 'interview'],
-    personnel: 5,
-    study_period: '2023.01.01 - 2023.02.02',
-    recruitment_period: '2023.01.01 - 2023.02.02',
-  },
-  {
-    id: 6,
-    title: '스터디명스터디명스터디명스터디명',
-    category: ['Frontend', 'Backend', 'interview'],
-    personnel: 5,
-    study_period: '2023.01.01 - 2023.02.02',
-    recruitment_period: '2023.01.01 - 2023.02.02',
-  },
-];
-
 const StudyManage = () => {
+  const router = useRouter();
+
   return (
-    <PageLayout>
+    <PageLayout className="flex flex-col items-center">
       <TitleArea>
-        <Title>개설한 스터디</Title>
+        <Title>내가 맡은 스터디</Title>
       </TitleArea>
-      {MY_STUDY_LIST.length > 0 ? (
-        <StudyList>
-          {MY_STUDY_LIST.map(
-            ({
-              id,
-              title,
-              category,
-              personnel,
-              study_period,
-              recruitment_period,
-            }) => (
-              <OpenStudyCard
-                key={id}
-                id={id}
-                title={title}
-                category={category}
-                personnel={personnel}
-                study_period={study_period}
-                recruitment_period={recruitment_period}
-              />
-            ),
-          )}
-          <Button className="w-[134px] h-9 mb-4" text="스터디 개설하기" />
-        </StudyList>
-      ) : (
-        <>
-          <div className="flex h-[70vh] items-center justify-center ">
-            <span className="text-center text-[#8A8A8A]">
-              등록한 과제가 없습니다. <br /> 새로운 과제를 등록해보세요!
-            </span>
-          </div>
-          <div className="flex justify-center">
-            <Button className="w-[134px] h-9" text="스터디 개설하기" />
-          </div>
-        </>
-      )}
+      <StudyListArea>
+        <Suspense fallback={<MyStudyListSkeleton />}>
+          <MyStudyList />
+        </Suspense>
+        <Button
+          className="h-9 w-[134px]"
+          text="스터디 개설하기"
+          onClick={() => router.push('/study/create')}
+        />
+      </StudyListArea>
     </PageLayout>
   );
 };
@@ -110,14 +36,17 @@ const Title = tw.span`
 `;
 
 const TitleArea = tw.div`
-  ml-48
-  mt-[125px]
+  w-[100%]
+  pl-48
+  pt-[125px]
 `;
 
-const StudyList = tw.div`
-  mt-5
+const StudyListArea = tw.div`
   flex
+  grow
   flex-col
   items-center
+  justify-between
   gap-y-5
+  py-5
 `;


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

<!--수정/추가한 작업 내용을 설명해주세요.-->
- close #111 

## 🧑‍💻 PR 세부 내용

<!-- 세부 내용을 설명해주세요.-->
- 무한 스크롤
- 스켈레톤 로딩
- 스터디 삭제

## 💡 구현 예정

- 스터디 기간, 모집 기간 표시

## 🗣️ 추신..

기존 페이지가 `/study/manage`에 구현되어 있어서 api 폴더 및 라우팅을 모두 `/study` 로 통일했는데, api 경로는 `{BASE_URL}/auth/...` 여서 api는 `/user`에 작성해야할지 고민입니다...

기간 관련 부분은 api 수정이 되는대로 업데이트 하겠습니다! 

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
<table>
<tr>
<td>스터디 O</td>
<td>스터디 X</td>
</tr>
<tr>
<td><img width="1065" alt="스터디 있을 때" src="https://github.com/crescenders/crescendo-frontend/assets/51291185/0a00d0e5-e15e-4cdf-b5ac-2f4748166a8f"></td>
<td><img width="1065" alt="스터디 없을 때" src="https://github.com/crescenders/crescendo-frontend/assets/51291185/aff1edd4-7f47-4998-b795-66be54f33ae9"></td>
</tr>
</table>


