### PR TITLE
[CRES-94] 스터디 참여 신청 api 연동

### DIFF
--- a/src/apis/study/studyApi.ts
+++ b/src/apis/study/studyApi.ts
@@ -38,6 +38,16 @@ const studyApi = {
     );
     return data;
   },
+  applyStudyGroup: async (
+    uuid: string,
+    message: string,
+  ): Promise<{ request_message: string }> => {
+    const { data } = await instance.post(
+      `/api/v1/studygroup/studies/${uuid}/members/`,
+      { request_message: message },
+    );
+    return data;
+  },
 };
 
 export default studyApi;

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -17,7 +17,7 @@ const ToastItem = ({ type, message }) => {
 
   return (
     <div
-      className={`fixed bottom-[47px] left-1/2 flex w-fit translate-x-[-50%] select-none justify-center rounded bg-dark px-12 py-3 transition-all duration-500 ease-in-out ${
+      className={`fixed bottom-[47px] left-1/2 z-[1000] flex w-fit translate-x-[-50%] select-none justify-center rounded bg-dark px-12 py-3 transition-all duration-500 ease-in-out ${
         isVisible ? 'opacity-80' : 'opacity-0'
       }`}
     >

--- a/src/components/detail/ApplyBottomSheet.tsx
+++ b/src/components/detail/ApplyBottomSheet.tsx
@@ -1,12 +1,33 @@
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import React, { useRef, useState } from 'react';
 import tw from 'tailwind-styled-components';
 import TextArea from '@components/common/TextArea';
 import Button from '@components/common/Button';
+import { useApplyStudy } from '@hooks/mutations/useApplyStudy';
+import useToast from '@hooks/useToast';
 
 const ApplyBottomSheet = () => {
   const ref = useRef<HTMLTextAreaElement>(null);
+  const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
+  const { showToast } = useToast();
+  const { mutate: applyStudy, isSuccess } = useApplyStudy();
+
+  const handleApplyStudy = () => {
+    const uuid = String(router.query.id);
+    const message = String(ref.current?.value);
+
+    if (!message.length) {
+      showToast({
+        type: 'fail',
+        message: '내용을 입력해주세요.',
+      });
+      return;
+    }
+    applyStudy({ uuid, message });
+    if (isSuccess) setIsOpen(false);
+  };
 
   return (
     <>
@@ -29,6 +50,7 @@ const ApplyBottomSheet = () => {
               <Button
                 text="제출하기"
                 className="h-[32px] w-[74px] rounded-full"
+                onClick={handleApplyStudy}
               />
             </div>
             <ApplyBtn

--- a/src/components/detail/ApplyBottomSheet.tsx
+++ b/src/components/detail/ApplyBottomSheet.tsx
@@ -12,7 +12,7 @@ const ApplyBottomSheet = () => {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const { showToast } = useToast();
-  const { mutate: applyStudy, isSuccess } = useApplyStudy();
+  const { mutate: applyStudy } = useApplyStudy();
 
   const handleApplyStudy = () => {
     const uuid = String(router.query.id);
@@ -26,7 +26,7 @@ const ApplyBottomSheet = () => {
       return;
     }
     applyStudy({ uuid, message });
-    if (isSuccess) setIsOpen(false);
+    setIsOpen(false);
   };
 
   return (

--- a/src/hooks/mutations/useApplyStudy.ts
+++ b/src/hooks/mutations/useApplyStudy.ts
@@ -1,0 +1,38 @@
+import studyApi from '@apis/study/studyApi';
+import useToast from '@hooks/useToast';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+type ApplyStudyParamType = {
+  uuid: string;
+  message: string;
+};
+
+type ErrorMessageType = {
+  [key: string]: string[];
+};
+
+export const useApplyStudy = () => {
+  const { showToast } = useToast();
+
+  return useMutation({
+    mutationFn: ({ uuid, message }: ApplyStudyParamType) =>
+      studyApi.applyStudyGroup(uuid, message),
+    onSuccess: () => {
+      showToast({
+        type: 'success',
+        message: '신청이 완료되었습니다.',
+      });
+    },
+    onError: (error: AxiosError) => {
+      const errorMessage = error.response?.data as ErrorMessageType;
+      showToast({
+        type: 'fail',
+        message: errorMessage.non_field_errors
+          ? '이미 신청한 스터디입니다.'
+          : '오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+      });
+    },
+    throwOnError: false,
+  });
+};

--- a/src/hooks/mutations/useApplyStudy.ts
+++ b/src/hooks/mutations/useApplyStudy.ts
@@ -1,6 +1,6 @@
 import studyApi from '@apis/study/studyApi';
 import useToast from '@hooks/useToast';
-import { useMutation } from '@tanstack/react-query';
+import { UseMutationResult, useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 type ApplyStudyParamType = {
@@ -12,27 +12,28 @@ type ErrorMessageType = {
   [key: string]: string[];
 };
 
-export const useApplyStudy = () => {
+export const useApplyStudy = (): UseMutationResult<
+  { request_message: string },
+  AxiosError<ErrorMessageType>,
+  ApplyStudyParamType
+> => {
   const { showToast } = useToast();
 
   return useMutation({
-    mutationFn: ({ uuid, message }: ApplyStudyParamType) =>
-      studyApi.applyStudyGroup(uuid, message),
+    mutationFn: ({ uuid, message }) => studyApi.applyStudyGroup(uuid, message),
     onSuccess: () => {
       showToast({
         type: 'success',
         message: '신청이 완료되었습니다.',
       });
     },
-    onError: (error: AxiosError) => {
-      const errorMessage = error.response?.data as ErrorMessageType;
+    onError: (error) => {
       showToast({
         type: 'fail',
-        message: errorMessage.non_field_errors
+        message: error.response?.data['non_field_errors']
           ? '이미 신청한 스터디입니다.'
           : '오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
       });
     },
-    throwOnError: false,
   });
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -26,7 +26,6 @@ const queryClient = new QueryClient({
     },
     mutations: {
       retry: 0,
-      throwOnError: false,
     },
   },
 });

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -26,7 +26,7 @@ const queryClient = new QueryClient({
     },
     mutations: {
       retry: 0,
-      throwOnError: true,
+      throwOnError: false,
     },
   },
 });


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

<!--수정/추가한 작업 내용을 설명해주세요.-->
- close #117 

## 🧑‍💻 PR 세부 내용

<!-- 세부 내용을 설명해주세요.-->
- 스터디 참여 신청 api 적용
- 신청 바텀 시트 z-index가 토스트 메시지보다 높아 토스트 메시지의 z-index를 수정했습니다.

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
- 빈 값 입력, 중복 신청
  ![ezgif com-video-to-gif](https://github.com/crescenders/crescendo-frontend/assets/51291185/478c95a5-48f2-4364-8067-6b91328965d8)

- 신청 성공
  ![ezgif com-video-to-gif (1)](https://github.com/crescenders/crescendo-frontend/assets/51291185/a8f8bc65-51a4-40ef-b9d8-640b6273e59a)



