### PR TITLE
[CRES-97] 검색 결과 페이지에서 뒤로가기를 했을 때 스켈레톤 UI가 뜨는 현상을 해결한다.

### DIFF
--- a/src/components/search/NotFoundStudyList.tsx
+++ b/src/components/search/NotFoundStudyList.tsx
@@ -8,7 +8,7 @@ const NotFoundStudyList = ({ keyword }: NotFoundStudyListProps) => {
   const router = useRouter();
 
   return (
-    <div className="flex w-full select-none flex-col items-center justify-center">
+    <div className="flex h-[60vh] w-full select-none flex-col items-center justify-center">
       {keyword ? (
         <p className="tracking-[-0.8px]">
           &apos;<span className="font-bold">{keyword}</span>

--- a/src/components/search/StudyList.tsx
+++ b/src/components/search/StudyList.tsx
@@ -15,6 +15,7 @@ const StudyList = () => {
     data: studies,
     fetchNextPage,
     hasNextPage,
+    isFetchingNextPage,
     isFetching,
   } = useGetStudyGroupList(params);
 
@@ -69,7 +70,7 @@ const StudyList = () => {
           />
         )}
       </StudyListContainer>
-      {isFetching && <StudyListSkeleton />}
+      {isFetchingNextPage && <StudyListSkeleton />}
       <div ref={targetRef} />
     </>
   );


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- close #119 
<!--수정/추가한 작업 내용을 설명해주세요.-->

## 🧑‍💻 PR 세부 내용
- 이전 페이지로 돌아갔을 때 isFetching은 true이나 isFetchingNextPage는 false입니다.
- isFetching -> isFetchingNextPage로 수정하여 해당 문제를 해결했습니다.
<!-- 세부 내용을 설명해주세요.-->

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
