### PR TITLE
[CRES-111] 배너에 보여주는 랜덤 태그 구현

### DIFF
--- a/src/apis/tag/tag.d.ts
+++ b/src/apis/tag/tag.d.ts
@@ -1,0 +1,3 @@
+type Tag = {
+  name: string;
+};

--- a/src/apis/tag/tagApi.ts
+++ b/src/apis/tag/tagApi.ts
@@ -1,0 +1,13 @@
+import instance from '@apis/instance';
+
+const tagApi = {
+  getTags: async (count = 3): Promise<Tag[]> => {
+    const { data } = await instance.get(
+      `/api/v1/studygroup/tags/?random_count=${count}`,
+    );
+
+    return data;
+  },
+};
+
+export default tagApi;

--- a/src/components/home/Banner.tsx
+++ b/src/components/home/Banner.tsx
@@ -3,9 +3,11 @@ import { useRouter } from 'next/router';
 import Lottie from 'lottie-react';
 import { useState } from 'react';
 import animation from '@public/animation/main.json';
+import { useGetTags } from '@hooks/queries/useGetTags';
 
 const Banner = () => {
   const router = useRouter();
+  const { data: tags } = useGetTags();
 
   const [keyword, setKeyword] = useState('');
 
@@ -58,25 +60,16 @@ const Banner = () => {
               onClick={handleSearchClick}
             />
           </div>
-          <ul className="flex h-[28px] w-[215px] cursor-pointer gap-3">
-            <li
-              className="flex items-center justify-center rounded-[26px] bg-[#A77EC4] px-[10px] py-[5px] text-white"
-              onClick={() => router.push(`/search?tags=React`)}
-            >
-              #React
-            </li>
-            <li
-              className="flex items-center justify-center rounded-[26px] bg-[#A77EC4] px-[10px] py-[5px] text-white"
-              onClick={() => router.push(`/search?tags=Django`)}
-            >
-              #Django
-            </li>
-            <li
-              className="flex items-center justify-center rounded-[26px] bg-[#A77EC4] px-[10px] py-[5px] text-white"
-              onClick={() => router.push(`/search?tags=Java`)}
-            >
-              #Java
-            </li>
+          <ul className="flex cursor-pointer gap-3">
+            {tags?.map(({ name }) => (
+              <li
+                key={name}
+                className="flex w-fit items-center justify-center overflow-hidden rounded-[26px] bg-[#A77EC4] px-3 py-0.5 text-15 text-white"
+                onClick={() => router.push(`/search?tags=${name}`)}
+              >
+                #{name}
+              </li>
+            ))}
           </ul>
         </div>
         <div className="flex h-[280px] max-w-[300px] items-center">

--- a/src/hooks/queries/useGetTags.ts
+++ b/src/hooks/queries/useGetTags.ts
@@ -1,0 +1,9 @@
+import tagApi from '@apis/tag/tagApi';
+import { useQuery } from '@tanstack/react-query';
+
+export const useGetTags = () => {
+  return useQuery({
+    queryKey: ['tags'],
+    queryFn: () => tagApi.getTags(),
+  });
+};


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- close #145 
<!--수정/추가한 작업 내용을 설명해주세요.-->

## 🧑‍💻 PR 세부 내용

<!-- 세부 내용을 설명해주세요.-->

## 리뷰어에게

@TGoddessana 적용을 해보니 어떤 태그는 현재 게시물 목록에 포함되어있는 태그도 있지만 이전에 삭제된 게시물에 포함되어있는 태그도 있고 처음보는 태그도 있더라구요. 혹시 태그가 생성되는 기준이 임의의 태그를 생성해서 저장해두는 방법과 이전에 작성된 게시물의 태그 히스토리를 기준으로 하는걸까요~?
