### PR TITLE
[CRES-139] 사용자 시나리오에 따른 E2E 테스트 작성

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -36,8 +36,10 @@ jobs:
       - name: Unit Test & Integration Test
         run: yarn test:coverage
 
-      - name: e2e Test
-        uses: cypress-io/github-action@v2
+      - name: E2E Test
+        uses: cypress-io/github-action@v6
         with:
-          install: false
-          command: yarn test:e2e
+          command-prefix: yarn dlx
+          start: yarn dev
+          wait-on: 'http://localhost:3000'
+          browser: chrome

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,5 +1,4 @@
 const { defineConfig } = require('cypress');
-const path = require('path');
 
 module.exports = defineConfig({
   e2e: {
@@ -9,14 +8,6 @@ module.exports = defineConfig({
     devServer: {
       framework: 'next',
       bundler: 'webpack',
-      webpackConfig: {
-        resolve: {
-          alias: {
-            '@components': path.resolve(__dirname, './src/components'),
-            '@pages': path.resolve(__dirname, './src/pages'),
-          },
-        },
-      },
     },
   },
 });

--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -1,4 +1,4 @@
-describe('LoginTest', () => {
+describe('Login Test', () => {
   it('비로그인 상태로 로그인 필요 페이지 접근시 /login으로 이동', () => {
     cy.visit('/mypage/edit');
     cy.url().should('include', '/login');
@@ -7,5 +7,12 @@ describe('LoginTest', () => {
   it('비로그인 상태로 로그인 필요 페이지 접근시 /login으로 이동', () => {
     cy.visit('/create');
     cy.url().should('include', '/login');
+  });
+
+  it('로그인 상태로 로그인 페이지에 접근할 경우 토큰은 삭제된다.', () => {
+    cy.setCookie('refreshToken', 'refresh');
+    cy.visit('/login');
+    cy.wait(1000);
+    cy.getCookie('refreshToken').should('be.null');
   });
 });

--- a/cypress/e2e/mobile.cy.ts
+++ b/cypress/e2e/mobile.cy.ts
@@ -1,0 +1,17 @@
+describe('Mobile Test', () => {
+  beforeEach(() => {
+    cy.visit('/', {
+      onBeforeLoad: (window) => {
+        Object.defineProperty(window.navigator, 'userAgent', {
+          value:
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1',
+        });
+      },
+    });
+  });
+
+  it('모바일에서 접속 시 링크 복사하기 버튼이 보여야 한다.', () => {
+    cy.get('button').contains('링크 복사하기');
+    cy.contains('PC 환경으로 접속해주세요');
+  });
+});

--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -1,0 +1,11 @@
+describe('Search Test', () => {
+  it('검색 페이지에서 최초 렌더링시 최신순 필터가 포함되어 있어야 한다.', () => {
+    cy.visit('/search');
+    cy.contains('최신순');
+  });
+
+  it('빈 값을 입력하면 필터링이 모두 해제되어야 하고 카테고리는 All이 선택되어야 한다.', () => {
+    cy.visit('/search');
+    cy.get('li').contains('All').should('have.class', 'border-[#8266FF]');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "test": "jest --watchAll",
     "test:coverage": "jest --coverage",
     "cypress:open": "cypress open --e2e --browser chrome",
-    "cypress:run": "cypress run --e2e --browser chrome --headless",
-    "test:e2e": "start-server-and-test dev http://localhost:3000 \"cypress run --e2e\""
+    "cypress:run": "cypress run --e2e --browser chrome --headless"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.7.2",


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- #207
<!--수정/추가한 작업 내용을 설명해주세요.-->

## 🧑‍💻 PR 세부 내용
- 핵심 기능에 대해서 테스트를 작성하였습니다.
- 컴포넌트 테스트는 RTL로 하기 때문에 웹팩 설정을 제거하였습니다.
- cypress-io/github-action@v2 -> v6 최신방식으로 변경 및 `yarn test:e2e` 스크립트 제거

<!-- 세부 내용을 설명해주세요.-->

## 리뷰어에게
`cypress:open`, `cypress:run`의 실행 결과가 다른데 원인을 모르겠네요 ㅠㅠ 그래서 소극적으로 작성하였습니다ㅠ

cypress 테스트 소요시간이 jest에 비해 10배 이상 길어서 핵심적인 기능만 테스트 하는 것이 좋아보입니다.

## 트러블 슈팅
- Yarn Berry를 사용하는 프로젝트는 github actions에서 cypress 모듈을 찾을 수 없습니다. `command-prefix: yarn dlx` 를 추가하여 해결하였습니다. https://github.com/cypress-io/github-action/issues/430
- 저희 프로젝트는 nginx, docker를 사용하고 있지 않아 github actions에서 별도의 서버가 없기 때문에 api 호출이 포함되어야만 하는 테스트는 통과하지 못합니다. 따라서 관련된 테스트를 모두 제거하였습니다. 추후에 테스트 작성하시게 되면 해당사항 유의하시면 될 것 같습니다
## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
