### PR TITLE
검색 엔진 최적화 및 초기 렌더링 속도 향상을 위한 SSR 적용

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,5 +2,8 @@ User-agent: *
 Disallow: /mypage/
 Disallow: /study/assignment/detail/
 Disallow: /study/assignment/submission/
+Disallow: /404
+Allow: /
 Allow: /study/detail/
 Allow: /study/assignment/
+Allow: /search

--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -6,7 +6,7 @@ type TextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
 };
 
 const TextArea = forwardRef<HTMLTextAreaElement, Partial<TextAreaProps>>(
-  ({ id, label, ...rest }, ref) => {
+  ({ id, label, className, ...rest }, ref) => {
     return (
       <div className="flex flex-col gap-y-2">
         {label && (
@@ -18,7 +18,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, Partial<TextAreaProps>>(
           ref={ref}
           id={id}
           {...rest}
-          className="h-[150px] w-[550px] resize-none rounded-lg border-[1px] border-line-primary p-4 outline-none placeholder:font-bold placeholder:text-text-primary focus:border-brand"
+          className={`h-[150px] w-[550px] resize-none rounded-lg border-[1px] border-line-primary p-4 outline-none placeholder:font-bold placeholder:text-text-primary focus:border-brand ${className}`}
         />
       </div>
     );

--- a/src/components/detail/ApplyBottomSheet.tsx
+++ b/src/components/detail/ApplyBottomSheet.tsx
@@ -7,14 +7,14 @@ import { usePostApplication } from '@hooks/mutations/usePostApplication';
 import useToast from '@hooks/useToast';
 import { useRecoilValue } from 'recoil';
 import { userState } from '@recoil/auth';
-import { useSuspenseGetStudyDetail } from '@hooks/queries/useGetStudy';
+import { useGetStudyDetail } from '@hooks/queries/useGetStudy';
 
 const ApplyBottomSheet = () => {
   const ref = useRef<HTMLTextAreaElement>(null);
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const { showToast } = useToast();
-  const { data: study } = useSuspenseGetStudyDetail(String(router.query.id));
+  const { data: study } = useGetStudyDetail(String(router.query.id));
   const { mutate: postApplication } = usePostApplication();
   const { username } = useRecoilValue(userState);
 
@@ -26,7 +26,7 @@ const ApplyBottomSheet = () => {
       });
       return;
     }
-    if (study.leaders[0].username === username) {
+    if (study?.leaders[0].username === username) {
       showToast({
         type: 'fail',
         message: '본인이 개설한 스터디에요.',

--- a/src/components/detail/StudyDetailContent.tsx
+++ b/src/components/detail/StudyDetailContent.tsx
@@ -1,19 +1,15 @@
 import DropBox from '@components/common/DropBox';
 import DeleteModal from '@components/modal/DeleteModal';
 import { useDeleteStudy } from '@hooks/mutations/useDeleteStudy';
-import {
-  useGetStudyDetail,
-  useSuspenseGetStudyDetail,
-} from '@hooks/queries/useGetStudy';
+import { useGetStudyDetail } from '@hooks/queries/useGetStudy';
 import useModal from '@hooks/useModal';
 import { userState } from '@recoil/auth';
 import { formatUTC } from '@utils/formatUTC';
 import { getProgress } from '@utils/getProgress';
-import DOMPurify from 'dompurify';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
-import ApplyBottomSheet from '@components/detail/ApplyBottomSheet';
+import useIsMounted from '@hooks/useIsMounted';
 
 const StudyDetailContent = () => {
   const router = useRouter();
@@ -21,11 +17,13 @@ const StudyDetailContent = () => {
 
   const { uuid } = useRecoilValue(userState);
   const { openModal, closeModal } = useModal();
-  const { data: study } = useSuspenseGetStudyDetail(id);
+  const { data: study } = useGetStudyDetail(id);
   const { mutate: deleteStudy } = useDeleteStudy();
+  const isMounted = useIsMounted();
 
   const topEvent = () => {
-    if (study.until_deadline >= 0) router.push(`/study/detail/edit/${id}`);
+    if (study && study.until_deadline >= 0)
+      router.push(`/study/detail/edit/${id}`);
     else alert('마감된 스터디는 수정할 수 없습니다.');
   };
 
@@ -48,23 +46,23 @@ const StudyDetailContent = () => {
     <>
       <div className="mx-auto my-0 mb-12 w-full max-w-2xl px-7">
         <div className="mt-[50px] flex flex-col gap-y-2">
-          <h1 className="text-24 font-bold">{study.post_title}</h1>
+          <h1 className="text-24 font-bold">{study?.post_title}</h1>
           <div className="flex gap-x-1">
             <span className="font-bold">
-              {study.leaders.map((v) => v.username)}
+              {study?.leaders.map((v) => v.username)}
             </span>
-            <span>({study.leaders[0].email})</span>
+            <span>({study?.leaders[0].email})</span>
           </div>
           <div className="flex justify-between">
             <span className="text-text-secondary">
-              작성일 {formatUTC(study.created_at as string)}
+              작성일 {formatUTC(study?.created_at as string)}
             </span>
-            {uuid === study.leaders[0].uuid && (
+            {isMounted && uuid === study?.leaders[0].uuid && (
               <DropBox topEvent={topEvent} bottomEvent={bottomEvent} />
             )}
           </div>
           <div className="relative mt-2 h-[254px] w-full overflow-hidden rounded-lg border-[1px] border-black">
-            <Image src={study.head_image as string} fill alt="head-image" />
+            <Image src={study?.head_image as string} fill alt="head-image" />
           </div>
           <div className="mt-7 flex gap-x-2">
             <div className="flex flex-1 flex-col gap-y-4">
@@ -72,13 +70,13 @@ const StudyDetailContent = () => {
                 <span className="whitespace-nowrap font-bold text-text-secondary">
                   스터디명
                 </span>
-                <span className="font-bold">{study.study_name}</span>
+                <span className="font-bold">{study?.study_name}</span>
               </div>
               <span className="whitespace-nowrap font-bold text-text-secondary">
                 카테고리
               </span>
               <ul className="flex flex-wrap gap-2">
-                {study.categories.map((category) => (
+                {study?.categories.map((category) => (
                   <li
                     key={category}
                     className="flex h-fit w-fit cursor-pointer list-none items-center justify-center rounded-[7px] border-[1.5px] border-[#8266FF] bg-white px-3 py-2 text-[13px] text-[#8266FF]"
@@ -94,21 +92,21 @@ const StudyDetailContent = () => {
                   스터디 기간
                 </span>
                 <span className="font-bold">
-                  {study.start_date} ~ {study.end_date}
+                  {study?.start_date} ~ {study?.end_date}
                 </span>
               </div>
               <div className="flex items-center gap-x-1.5">
                 <span className="whitespace-nowrap font-bold text-text-secondary">
                   모집 기간
                 </span>
-                <span className="font-bold">{study.deadline}</span>
+                <span className="font-bold">{study?.deadline}</span>
                 <span className="text-13 font-bold text-status-error">
                   {study && study.until_deadline > 0
                     ? `(D-${study.until_deadline})`
                     : '마감'}
                 </span>
               </div>
-              {study.until_deadline < 0 && (
+              {study && study.until_deadline < 0 && (
                 <div className="flex items-center gap-x-1.5">
                   <span className="whitespace-nowrap font-bold text-text-secondary">
                     진행도
@@ -125,7 +123,7 @@ const StudyDetailContent = () => {
               태그
             </span>
             <ul className="ml-1 flex flex-wrap gap-x-1.5 gap-y-2">
-              {study.tags.map((tag) => (
+              {study?.tags.map((tag) => (
                 <li
                   key={tag}
                   className="h-fit w-fit cursor-pointer rounded-full border-[1px] border-[#C8B4FF] px-3 py-1 text-13"
@@ -142,12 +140,11 @@ const StudyDetailContent = () => {
           <div
             className="prose mt-10"
             dangerouslySetInnerHTML={{
-              __html: DOMPurify.sanitize(study?.post_content as string),
+              __html: study?.post_content as string,
             }}
           />
         </div>
       </div>
-      <ApplyBottomSheet />
     </>
   );
 };

--- a/src/components/detail/SubmissionDetailContent.tsx
+++ b/src/components/detail/SubmissionDetailContent.tsx
@@ -3,7 +3,7 @@ import { useRecoilValue } from 'recoil';
 import DropBox from '@components/common/DropBox';
 import DeleteModal from '@components/modal/DeleteModal';
 import { useDeleteSubmissionDetail } from '@hooks/mutations/useDeleteSubmission';
-import { useGetSubmissionDetail } from '@hooks/queries/useGetSubmission';
+import { useSuspenseGetSubmissionDetail } from '@hooks/queries/useGetSubmission';
 import useModal from '@hooks/useModal';
 import { userState } from '@recoil/auth';
 import { formatUTC } from '@utils/formatUTC';
@@ -15,7 +15,7 @@ const SubmissionDetailContent = () => {
   const { uuid: userId } = useRecoilValue(userState);
   const { openModal, closeModal } = useModal();
   const { mutate } = useDeleteSubmissionDetail();
-  const { data } = useGetSubmissionDetail(
+  const { data } = useSuspenseGetSubmissionDetail(
     uuid,
     Number(assignmentId),
     Number(submissionId),

--- a/src/components/home/Banner.tsx
+++ b/src/components/home/Banner.tsx
@@ -68,7 +68,7 @@ const Banner = () => {
             {tags?.map(({ name }) => (
               <li
                 key={name}
-                className="flex w-fit items-center justify-center overflow-hidden rounded-[26px] bg-[#A77EC4] px-3 py-0.5 text-15 text-white"
+                className="flex w-fit whitespace-nowrap items-center justify-center overflow-hidden rounded-[26px] bg-[#A77EC4] px-3 py-0.5 text-15 text-white"
                 onClick={() => router.push(`/search?tags=${name}`)}
               >
                 #{name}

--- a/src/components/submission/SubmissionList.tsx
+++ b/src/components/submission/SubmissionList.tsx
@@ -7,7 +7,7 @@ import SubmissionListSkeleton from '@components/skeleton/SubmissionListSkeleton'
 
 const SubmissionList = () => {
   const router = useRouter();
-  const [uuid, assignmentId] = router.query.id as string[];
+  const [uuid, assignmentId] = (router.query.id as string[]) || [];
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isFetching } =
     useGetSubmissionList(uuid, Number(assignmentId));
   const { targetRef, isIntersecting } = useIntersection({ threshold: 0.4 });

--- a/src/hooks/queries/useGetAssignment.ts
+++ b/src/hooks/queries/useGetAssignment.ts
@@ -18,6 +18,14 @@ export const useGetAssignmentList = (uuid: string) => {
 };
 
 export const useGetAssignmentDetail = (uuid: string, id: number) => {
+  return useQuery({
+    queryKey: ['useGetAssignmentDetail', uuid, id],
+    queryFn: () => assingmentApi.getAssignmentDetail(uuid, id),
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
+export const useSuspenseGetAssignmentDetail = (uuid: string, id: number) => {
   return useSuspenseQuery({
     queryKey: ['useGetAssignmentDetail', uuid, id],
     queryFn: () => assingmentApi.getAssignmentDetail(uuid, id),

--- a/src/hooks/queries/useGetAssignment.ts
+++ b/src/hooks/queries/useGetAssignment.ts
@@ -1,5 +1,9 @@
 import assingmentApi from '@apis/assignment/assignmentApi';
-import { useQuery, useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import {
+  useQuery,
+  useSuspenseInfiniteQuery,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
 
 export const useGetAssignmentList = (uuid: string) => {
   return useSuspenseInfiniteQuery({
@@ -14,7 +18,7 @@ export const useGetAssignmentList = (uuid: string) => {
 };
 
 export const useGetAssignmentDetail = (uuid: string, id: number) => {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ['useGetAssignmentDetail', uuid, id],
     queryFn: () => assingmentApi.getAssignmentDetail(uuid, id),
     staleTime: 5 * 60 * 1000,

--- a/src/hooks/queries/useGetStudy.ts
+++ b/src/hooks/queries/useGetStudy.ts
@@ -33,7 +33,7 @@ export const useGetRandomStudyGroupList = () => {
 
 export const useSuspenseGetStudyDetail = (id: string) => {
   return useSuspenseQuery({
-    queryKey: ['useSuspenseGetStudyDetail', id],
+    queryKey: ['useGetStudyDetail', id],
     queryFn: () => studyApi.getStudyDetail(id),
     staleTime: 5 * 60 * 1000,
   });

--- a/src/hooks/queries/useGetSubmission.ts
+++ b/src/hooks/queries/useGetSubmission.ts
@@ -1,5 +1,6 @@
 import submissionApi from '@apis/submission/submissionApi';
 import {
+  useQuery,
   useSuspenseInfiniteQuery,
   useSuspenseQuery,
 } from '@tanstack/react-query';
@@ -16,7 +17,7 @@ export const useGetSubmissionList = (uuid: string, id: number) => {
   });
 };
 
-export const useGetSubmissionDetail = (
+export const useSuspenseGetSubmissionDetail = (
   uuid: string,
   assignmentId: number,
   submissionId: number,
@@ -25,5 +26,18 @@ export const useGetSubmissionDetail = (
     queryKey: ['useGetSubmissionDetail', uuid, assignmentId, submissionId],
     queryFn: () =>
       submissionApi.getSubmissionDetail(uuid, assignmentId, submissionId),
+  });
+};
+
+export const useGetSubmissionDetail = (
+  uuid: string,
+  assignmentId: number,
+  submissionId: number,
+) => {
+  return useQuery({
+    queryKey: ['useGetSubmissionDetail', uuid, assignmentId, submissionId],
+    queryFn: () =>
+      submissionApi.getSubmissionDetail(uuid, assignmentId, submissionId),
+    enabled: !!uuid && !!assignmentId && !!submissionId,
   });
 };

--- a/src/hooks/queries/useGetSubmission.ts
+++ b/src/hooks/queries/useGetSubmission.ts
@@ -1,5 +1,8 @@
 import submissionApi from '@apis/submission/submissionApi';
-import { useQuery, useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import {
+  useSuspenseInfiniteQuery,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
 
 export const useGetSubmissionList = (uuid: string, id: number) => {
   return useSuspenseInfiniteQuery({
@@ -18,10 +21,9 @@ export const useGetSubmissionDetail = (
   assignmentId: number,
   submissionId: number,
 ) => {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ['useGetSubmissionDetail', uuid, assignmentId, submissionId],
     queryFn: () =>
       submissionApi.getSubmissionDetail(uuid, assignmentId, submissionId),
-    enabled: !!uuid && !!assignmentId && !!submissionId,
   });
 };

--- a/src/hooks/queries/useGetTags.ts
+++ b/src/hooks/queries/useGetTags.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 export const useGetTags = () => {
   return useQuery({
-    queryKey: ['tags'],
+    queryKey: ['useGetTags'],
     queryFn: () => tagApi.getTags(),
   });
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,9 @@ import Link from 'next/link';
 import { categories } from '@constants/categories';
 import RandomStudyList from '@components/home/RandomStudyList';
 import HomeLayout from '@components/common/HomeLayout';
+import { GetServerSideProps } from 'next';
+import { QueryClient, dehydrate } from '@tanstack/react-query';
+import studyApi from '@apis/study/studyApi';
 
 const Home = () => {
   return (
@@ -25,6 +28,21 @@ const Home = () => {
       </section>
     </HomeLayout>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: ['useGetRandomStudyGroupList'],
+    queryFn: () => studyApi.getStudyGroupList('?random=true'),
+  });
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+  };
 };
 
 export default Home;

--- a/src/pages/study/assignment/detail/[...id].tsx
+++ b/src/pages/study/assignment/detail/[...id].tsx
@@ -1,11 +1,17 @@
+import Loader from '@components/common/Loader';
 import MenuBar from '@components/common/MenuBar';
 import PageLayout from '@components/common/PageLayout';
+import SSRSafeSuspense from '@components/common/SSRSafeSuspense';
 import AssignmentDetailContent from '@components/detail/AssignmentDetailContent';
+import ErrorBoundary from '@components/errorboundary/ErrorBoundary';
+import ErrorFallback from '@components/errorboundary/ErrorFallback';
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 
 const AssignmentDetail = () => {
   const router = useRouter();
   const [uuid, id] = (router.query.id as string[]) || [];
+  const { reset } = useQueryErrorResetBoundary();
 
   return (
     <PageLayout>
@@ -19,7 +25,11 @@ const AssignmentDetail = () => {
           centerPath={`/study/assignment/${uuid}`}
           rightPath={`/study/member/${uuid}`}
         />
-        <AssignmentDetailContent />
+        <ErrorBoundary fallback={ErrorFallback} reset={reset}>
+          <SSRSafeSuspense fallback={<Loader isFull />}>
+            <AssignmentDetailContent />
+          </SSRSafeSuspense>
+        </ErrorBoundary>
       </div>
     </PageLayout>
   );

--- a/src/pages/study/assignment/submission/detail/[...id].tsx
+++ b/src/pages/study/assignment/submission/detail/[...id].tsx
@@ -2,10 +2,16 @@ import { useRouter } from 'next/router';
 import MenuBar from '@components/common/MenuBar';
 import PageLayout from '@components/common/PageLayout';
 import SubmissionDetailContent from '@components/detail/SubmissionDetailContent';
+import ErrorBoundary from '@components/errorboundary/ErrorBoundary';
+import SSRSafeSuspense from '@components/common/SSRSafeSuspense';
+import Loader from '@components/common/Loader';
+import ErrorFallback from '@components/errorboundary/ErrorFallback';
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 
 const SubmissionDetail = () => {
   const router = useRouter();
   const [uuid] = (router.query.id as string[]) || [''];
+  const { reset } = useQueryErrorResetBoundary();
 
   return (
     <PageLayout>
@@ -19,7 +25,11 @@ const SubmissionDetail = () => {
           centerPath={`/study/assignment/${uuid}`}
           rightPath={`/study/member/${uuid}`}
         />
-        <SubmissionDetailContent />
+        <ErrorBoundary fallback={ErrorFallback} reset={reset}>
+          <SSRSafeSuspense fallback={<Loader isFull />}>
+            <SubmissionDetailContent />
+          </SSRSafeSuspense>
+        </ErrorBoundary>
       </div>
     </PageLayout>
   );

--- a/src/pages/study/detail/[id].tsx
+++ b/src/pages/study/detail/[id].tsx
@@ -2,8 +2,10 @@ import MenuBar from '@components/common/MenuBar';
 import PageLayout from '@components/common/PageLayout';
 import { useRouter } from 'next/router';
 import StudyDetailContent from '@components/detail/StudyDetailContent';
-import StudyDetailSkeleton from '@components/skeleton/StudyDetailSkeleton';
-import SSRSafeSuspense from '@components/common/SSRSafeSuspense';
+import { GetServerSideProps } from 'next';
+import { QueryClient, dehydrate } from '@tanstack/react-query';
+import studyApi from '@apis/study/studyApi';
+import ApplyBottomSheet from '@components/detail/ApplyBottomSheet';
 
 const StudyDetail = () => {
   const router = useRouter();
@@ -21,11 +23,26 @@ const StudyDetail = () => {
           rightPath={`/study/member/${id}`}
         />
       </div>
-      <SSRSafeSuspense fallback={<StudyDetailSkeleton />}>
-        <StudyDetailContent />
-      </SSRSafeSuspense>
+      <StudyDetailContent />
+      <ApplyBottomSheet />
     </PageLayout>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+  const id = String(query.id);
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: ['useGetStudyDetail', id],
+    queryFn: () => studyApi.getStudyDetail(id),
+  });
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+  };
 };
 
 export default StudyDetail;


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- close #228 
<!--수정/추가한 작업 내용을 설명해주세요.-->

## 🧑‍💻 PR 세부 내용
- 메인 페이지, 상세 페이지 클라이언트 -> 서버 사이드 렌더링 적용
- 메인 페이지와 검색 페이지도 색인화를 허용하도록 robots.txt 파일 수정
- 과제 관련 페이지의 Layout Shift 현상 해결을 위한 Suspense 재적용
<!-- 세부 내용을 설명해주세요.-->

## 이슈
메인 페이지에서는 두 개의 API를 요청합니다.
``` ts
await queryClient.prefetch(['tags'])
await queryClient.prefetch(['random'])
```
의 형태로 요청하지만 tags의 API 요청 수행이 끝난 후에 random API를 요청하기 때문에 waterfall 현상이 발생합니다.

따라서, 병렬적으로 API를 요청하기 위해 `Promise.all()`를 사용하였습니다.
``` ts
await Promise.all([
  queryClient.prefetchQuery(['tags']),
  queryClient.prefetchQuery(['random'])
])
```
하지만 여전히 문제는 발생하였습니다.
랜덤 API의 리소스가 태그 API보다 크기 때문에 랜덤 API만 서버 사이드에서 렌더링하도록 적용하였고, 태그 API는 이후 클라이언트 사이드에서 렌더링을 거치는 방식으로 적용하였습니다.

결론적으로 메인 페이지의 초기 렌더링 속도를 2.97s -> 1.8s (1.1s 감소)로 개선할 수 있었습니다.