### PR TITLE
스터디 수정 페이지 오류 해결

### DIFF
--- a/src/components/manage/MyStudyList.tsx
+++ b/src/components/manage/MyStudyList.tsx
@@ -51,7 +51,7 @@ const MyStudyList = () => {
       <div ref={targetRef} />
     </>
   ) : (
-    <div className="flex grow items-center justify-center ">
+    <div className="flex grow items-center justify-center">
       <span className="text-center text-[#8A8A8A]">
         개설한 스터디가 없습니다. <br /> 새로운 스터디를 개설해보세요!
       </span>

--- a/src/pages/mypage/manage.tsx
+++ b/src/pages/mypage/manage.tsx
@@ -10,11 +10,11 @@ const StudyManage = () => {
 
   return (
     <PageLayout>
-      <div className="flex w-full flex-col items-start justify-start px-7 pt-[125px]">
+      <div className="flex min-h-full w-full flex-col items-start justify-start px-7 pt-[125px]">
         <div className="flex w-full justify-center">
           <h1 className="w-[645px] text-20 font-bold">내가 맡은 스터디</h1>
         </div>
-        <div className="flex w-full grow flex-col items-center justify-between gap-y-5 py-5">
+        <div className="flex w-full grow flex-col items-center justify-between gap-y-5 pb-28 pt-5">
           <Suspense fallback={<MyStudyListSkeleton />}>
             <MyStudyList />
           </Suspense>

--- a/src/pages/study/detail/edit/[id].tsx
+++ b/src/pages/study/detail/edit/[id].tsx
@@ -19,7 +19,7 @@ const EditStudy = () => {
   const { mutate: editStudy, isPending } = useEditStudy();
 
   useEffect(() => {
-    if (study?.is_closed || uuid !== study?.leaders[0].uuid) {
+    if (study && (study.is_closed || uuid !== study.leaders[0].uuid)) {
       router.replace(`/study/detail/${id}`);
       showToast({
         type: 'fail',
@@ -66,3 +66,13 @@ const EditStudy = () => {
 };
 
 export default EditStudy;
+
+export const getServerSideProps = async ({
+  params: { id },
+}: {
+  params: { id: string };
+}) => {
+  return {
+    props: {},
+  };
+};


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

<!--수정/추가한 작업 내용을 설명해주세요.-->
- close #253

## 🧑‍💻 PR 세부 내용

<!-- 세부 내용을 설명해주세요.-->
- 스터디 수정 페이지에서 새로고침시 발생했던 오류 해결
  - useEffect 훅 내부에서 study가 있는지 추가적으로 확인
- 새로고침시 초반에 한 번 스터디 id가 undefined인 상태로 요청이 보내졌던 현상 해결

> 해결은 어찌저찌 됐지만... 애초에 스터디 작성 폼 설계를 잘못한 것 같아서 슬푸네여 허허 ㅠㅠㅠㅠ 아예 getServerSideProps로 스터디 상세 정보를 받아오는 방법도 생각해봤는데 좀 불필요하게 사용하는 것 같아서 틀었습니다...

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
