### PR TITLE
검색 필터링을 변경할 때 로딩 UI가 보이지 않는 문제 수정

### DIFF
--- a/src/components/search/StudyList.tsx
+++ b/src/components/search/StudyList.tsx
@@ -27,49 +27,51 @@ const StudyList = () => {
   return (
     <>
       <ul className="flex flex-wrap justify-center gap-8 px-5 pb-8">
-        {studies.pages.flatMap((page) => page.results).length > 0 ? (
-          studies.pages.flatMap((pages) =>
-            pages.results.map(
-              ({
-                uuid,
-                head_image,
-                leaders,
-                post_title,
-                study_name,
-                is_closed,
-                tags,
-                current_member_count,
-                member_limit,
-                until_deadline,
-              }) => (
-                <Card
-                  path={`/study/detail/${uuid}`}
-                  key={uuid}
-                  size="big"
-                  title={post_title}
-                  studyName={study_name}
-                  writer={leaders[0] && leaders[0].username} // admin 페이지에서 생성한 게시물은 leaders가 없다. 추후 수정 필요
-                  tags={tags}
-                  isClosed={is_closed}
-                  img={head_image}
-                  participant={current_member_count}
-                  personnel={member_limit}
-                  deadline={until_deadline}
-                />
+        {!isFetching ? (
+          studies.pages.flatMap((page) => page.results).length > 0 ? (
+            studies.pages.flatMap((pages) =>
+              pages.results.map(
+                ({
+                  uuid,
+                  head_image,
+                  leaders,
+                  post_title,
+                  study_name,
+                  is_closed,
+                  tags,
+                  current_member_count,
+                  member_limit,
+                  until_deadline,
+                }) => (
+                  <Card
+                    path={`/study/detail/${uuid}`}
+                    key={uuid}
+                    size="big"
+                    title={post_title}
+                    studyName={study_name}
+                    writer={leaders[0] && leaders[0].username} // admin 페이지에서 생성한 게시물은 leaders가 없다. 추후 수정 필요
+                    tags={tags}
+                    isClosed={is_closed}
+                    img={head_image}
+                    participant={current_member_count}
+                    personnel={member_limit}
+                    deadline={until_deadline}
+                  />
+                ),
               ),
-            ),
+            )
+          ) : (
+            <NotFoundStudyList
+              keyword={
+                (router.query.post_title as string) ||
+                (router.query.study_name as string) ||
+                (router.query.tags as string)
+              }
+            />
           )
-        ) : (
-          <NotFoundStudyList
-            keyword={
-              (router.query.post_title as string) ||
-              (router.query.study_name as string) ||
-              (router.query.tags as string)
-            }
-          />
-        )}
+        ) : null}
+        {(isFetching || isFetchingNextPage) && <StudyListSkeleton />}
       </ul>
-      {isFetchingNextPage && <StudyListSkeleton />}
       <div ref={targetRef} />
     </>
   );

--- a/src/hooks/queries/useGetStudy.ts
+++ b/src/hooks/queries/useGetStudy.ts
@@ -21,6 +21,8 @@ export const useGetStudyGroupList = (params = '') => {
     getNextPageParam: (lastPage) => {
       return lastPage.next ? lastPage.next.split('?')[1] : undefined;
     },
+    staleTime: 0,
+    gcTime: 0,
   });
 };
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -32,6 +32,12 @@ const Search = () => {
     studySearchRouter(value);
   };
 
+  const handleAllCategoryClick = () => {
+    router.replace(router.pathname);
+    setLeftValue('최신순');
+    setRightValue('모집여부');
+  };
+
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!(e.target instanceof HTMLInputElement) || !inputRef.current) return;
     const { value } = inputRef.current;
@@ -92,9 +98,7 @@ const Search = () => {
                 'border-[#8266FF] text-[#8266FF]'
               }`}
               onClick={() => {
-                id === 0
-                  ? router.replace(router.pathname)
-                  : handleCategoryList(name);
+                id === 0 ? handleAllCategoryClick() : handleCategoryList(name);
               }}
             >
               {name}


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- close #276
<!--수정/추가한 작업 내용을 설명해주세요.-->

## 🧑‍💻 PR 세부 내용
- 검색 필터링을 적용할 때 새로 페칭하는 것이 아닌 내부에서 캐싱된 값을 찾습니다. 따라서, `isFetching`의 값이 `false`이기 때문에 스켈레톤 UI가 보이지 않는 문제가 발생했습니다. 따라서, useGetStudy의 `staleTime: 0`으로 설정하고 한 번 검색했던 조건으로 재검색 할 경우 fetching 하는 동안 이전의 데이터를 보여주기 때문에 `gcTime` 또한 0으로 설정하였습니다.

- 검색 필터링이 초기화 될 때 마감여부 셀렉트 박스가 초기화 되지 않았습니다. 누락된 해당 부분을 추가했습니다.

<!-- 세부 내용을 설명해주세요.-->

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
