### PR TITLE
staleTime 디폴트 옵션 조정

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -31,7 +31,7 @@ export default function App({ Component, pageProps }: AppProps) {
             retry: 0,
             refetchOnWindowFocus: false,
             throwOnError: true,
-            staleTime: 60 * 1000,
+            staleTime: 5 * 1000,
           },
           mutations: {
             retry: 0,


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- close #279 
<!--수정/추가한 작업 내용을 설명해주세요.-->

## 🧑‍💻 PR 세부 내용
SSR 과정을 거치고 클라이언트에서 재페칭하는 것을 방지하기 위해 staleTime의 기본값을 60초로 설정하였습니다.
하지만 이전 이슈를 수정하는 과정에서 너무 과하게 설정되어 있는 느낌을 받았고 [TanStack GitHub Repo](https://github.com/TanStack/query/blob/main/examples/react/nextjs-suspense-streaming/src/app/providers.tsx)에서 또한 5초로 Best Practice를 채택하고 있기 때문에 5초로 수정합니다.
<!-- 세부 내용을 설명해주세요.-->

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
